### PR TITLE
P5R Library

### DIFF
--- a/Source/AtlusScriptLibrary/AtlusScriptLibrary.csproj
+++ b/Source/AtlusScriptLibrary/AtlusScriptLibrary.csproj
@@ -467,6 +467,33 @@
     <Content Include="Libraries\Persona3\Modules\Common\Functions.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Libraries\Persona5Royal.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Libraries\Persona5Royal\MessageScriptLibrary.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Libraries\Persona5Royal\Modules\AI\Functions.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Libraries\Persona5Royal\Modules\Common\Functions.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Libraries\Persona5Royal\Modules\Facility\Functions.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Libraries\Persona5Royal\Modules\Field\Functions.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Libraries\Persona5Royal\Modules\Net\Functions.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Libraries\Persona5Royal\Modules\Social\Functions.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Libraries\Persona5Royal\FlowScriptModules.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="MessageScriptLanguage\Compiler\Parser\MessageScriptLexer.g4" />
     <None Include="MessageScriptLanguage\Compiler\Parser\MessageScriptLexer.tokens" />
     <None Include="MessageScriptLanguage\Compiler\Parser\MessageScriptParser.g4" />

--- a/Source/AtlusScriptLibrary/Libraries/Persona5Royal.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona5Royal.json
@@ -1,0 +1,6 @@
+{
+  "Name": "Persona 5 Royal",
+  "ShortName": "p5r",
+  "FlowScriptModulesPath": "Persona5Royal\\FlowScriptModules.json",
+  "MessageScriptLibraryPath": "Persona5Royal\\MessageScriptLibrary.json"
+}

--- a/Source/AtlusScriptLibrary/Libraries/Persona5Royal/FlowScriptModules.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona5Royal/FlowScriptModules.json
@@ -1,0 +1,50 @@
+[
+  {
+    "Name": "Common",
+    "ShortName": "Common",
+    "Description": "",
+    "ConstantsPath": "",
+    "EnumsPath": "",
+    "FunctionsPath": "Persona5Royal\\Modules\\Common\\Functions.json"
+  },
+  {
+    "Name": "Field",
+    "ShortName": "Field",
+    "Description": "",
+    "ConstantsPath": "",
+    "EnumsPath": "",
+    "FunctionsPath": "Persona5Royal\\Modules\\Field\\Functions.json"
+  },
+  {
+    "Name": "AI",
+    "ShortName": "AI",
+    "Description": "",
+    "ConstantsPath": "",
+    "EnumsPath": "",
+    "FunctionsPath": "Persona5Royal\\Modules\\AI\\Functions.json"
+  },
+  {
+    "Name": "Social",
+    "ShortName": "Social",
+    "Description": "",
+    "ConstantsPath": "",
+    "EnumsPath": "",
+    "FunctionsPath": "Persona5Royal\\Modules\\Social\\Functions.json"
+  },
+  {
+    "Name": "Facility",
+    "ShortName": "Facility",
+    "Description": "",
+    "ConstantsPath": "",
+    "EnumsPath": "",
+    "FunctionsPath": "Persona5Royal\\Modules\\Facility\\Functions.json"
+  },
+  {
+    "Name": "Net",
+    "ShortName": "Net",
+    "Description": "",
+    "ConstantsPath": "",
+    "EnumsPath": "",
+    "FunctionsPath": "Persona5Royal\\Modules\\Net\\Functions.json"
+  }
+]

--- a/Source/AtlusScriptLibrary/Libraries/Persona5Royal/MessageScriptLibrary.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona5Royal/MessageScriptLibrary.json
@@ -1,0 +1,664 @@
+[
+  {
+    "Index": 0,
+    "Name": "",
+    "Description": "",
+    "Functions": [
+      {
+        "Index": 0,
+        "Name": "@Unused",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 1,
+        "Name": "clr",
+        "Description": "Sets the current text color to the color specified by the given color index.",
+        "Parameters": [
+          {
+            "Name": "colorIndex",
+            "Description": "The index of the color to set the current text color to."
+          }
+        ]
+      },
+      {
+        "Index": 2,
+        "Name": "@Unused",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 3,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 4,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 5,
+        "Name": "@Unused",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 6,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 7,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      }
+    ]
+  },
+
+  {
+    "Index": 1,
+    "Name": "",
+    "Description": "",
+    "Functions": [
+      {
+        "Index": 0,
+        "Name": "@Unused",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 1,
+        "Name": "w",
+        "Description": "Wait for player input.",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 2,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 3,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 4,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 5,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 6,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 7,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 8,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 9,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 10,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      }
+    ]
+  },
+
+  {
+    "Index": 2,
+    "Name": "",
+    "Description": "",
+    "Functions": [
+      {
+        "Index": 0,
+        "Name": "@Unused",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 1,
+        "Name": "s",
+        "Description": "Indicates the start of a line",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 2,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 3,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 4,
+        "Name": "var",
+        "Description": "Loads name previously defined by SET_MSG_VAR",
+        "Parameters": [
+          {
+            "Name": "VariableID",
+            "Description": "The ID of the variable set by SET_MSG_VAR function."
+          }
+        ]
+      },
+      {
+        "Index": 5,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 6,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 7,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      }
+    ]
+  },
+
+  {
+    "Index": 3,
+    "Name": "",
+    "Description": "Voice playing functions.",
+    "Functions": [
+      {
+        "Index": 0,
+        "Name": "@Unused",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 1,
+        "Name": "vp",
+        "Description": "Plays a voice sound cue from a specified sound bank.",
+        "Parameters": [
+          {
+            "Name": "eventIdMajor",
+            "Description": "Major id of the event."
+          },
+          {
+            "Name": "eventIdMinor",
+            "Description": "Minor id of the event."
+          },
+          {
+            "Name": "eventIdSub",
+            "Description": "Sub id of the event."
+          },
+          {
+            "Name": "cueId",
+            "Description": "The id of the sound que in the sound bank."
+          },
+          {
+            "Name": "param5",
+            "Description": "Unknown value."
+          },
+          {
+            "Name": "param6",
+            "Description": "Unknown value."
+          }
+        ]
+      }
+    ]
+  },
+
+  {
+    "Index": 4,
+    "Name": "",
+    "Description": "",
+    "Functions": [
+      {
+        "Index": 0,
+        "Name": "@Unused",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 1,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 2,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 3,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 4,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 5,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 6,
+        "Name": "bup",
+        "Description": "Sets the bustup to display.",
+        "Parameters": [
+          {
+            "Name": "param1",
+            "Description": "Unknown value."
+          },
+          {
+            "Name": "characterId",
+            "Description": "The id of the character."
+          },
+          {
+            "Name": "expressionId",
+            "Description": "The id of the character's expression."
+          },
+          {
+            "Name": "costumeId",
+            "Description": "The id of the character's costume."
+          },
+          {
+            "Name": "param5",
+            "Description": "Unknown value."
+          }
+        ]
+      },
+      {
+        "Index": 7,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 8,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 9,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 10,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 11,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 12,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 13,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 14,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 15,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 16,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 17,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 18,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 19,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 20,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 21,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 22,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 23,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 24,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 25,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 26,
+        "Name": "ref",
+        "Description": "References the caption message",
+        "Parameters": [
+          {
+            "Name": "RelativeID",
+            "Description": "This just seems to be a relative ID of the caption message"
+          },
+          {
+            "Name": "GlobalID",
+            "Description": "And this is the actual ID of it (GENERIC_HELP_<this>)."
+          }
+        ]
+      },
+      {
+        "Index": 27,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 28,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 29,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      }
+    ]
+  },
+
+  {
+    "Index": 5,
+    "Name": "",
+    "Description": "",
+    "Functions": [
+      {
+        "Index": 0,
+        "Name": "@Unused",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 1,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 2,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 3,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 4,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 5,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 6,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 7,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 8,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 9,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 10,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 11,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 12,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 13,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 14,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 15,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 16,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      }
+    ]
+  },
+
+  {
+    "Index": 6,
+    "Name": "",
+    "Description": "",
+    "Functions": [
+      {
+        "Index": 0,
+        "Name": "@Unused",
+        "Description": "",
+        "Parameters": [
+        ]
+      },
+      {
+        "Index": 1,
+        "Name": "",
+        "Description": "",
+        "Parameters": [
+        ]
+      }
+    ]
+  }
+
+]

--- a/Source/AtlusScriptLibrary/Libraries/Persona5Royal/Modules/AI/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona5Royal/Modules/AI/Functions.json
@@ -1,0 +1,6193 @@
+[
+    {
+        "Index":  "0x2000",
+        "ReturnType":  "int",
+        "Name":  "AI_RND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2001",
+        "ReturnType":  "void",
+        "Name":  "AI_ACT_ATTACK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2002",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_RND",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2003",
+        "ReturnType":  "void",
+        "Name":  "AI_ACT_SKILL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2004",
+        "ReturnType":  "void",
+        "Name":  "AI_DEBUG_PRINT",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "string",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2005",
+        "ReturnType":  "void",
+        "Name":  "AI_DEBUG_PRINT_VALUE",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2006",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRID_VOID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2007",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYHP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2008",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYMP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2009",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRHP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x200a",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENHP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x200b",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENHP_O",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x200c",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYLV_O",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x200d",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRLV_O",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x200e",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_EN_LV_O",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x200f",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRCNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2010",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENCNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2011",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2012",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2013",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2014",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2015",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2016",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRHOJO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2017",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENHOJO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2018",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ESCAPE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2019",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_SUMMON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x201a",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_SENSEI",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x201b",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYHANSYA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x201c",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRHANSYA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x201d",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENHANSYA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x201e",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYKYUSYU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x201f",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRKYUSYU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2020",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENKYUSYU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2021",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYMUKOU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2022",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRMUKOU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2023",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENMUKOU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2024",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYWEAK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2025",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRWEAK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2026",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENWEAK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2027",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYUSEATTR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2028",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRUSEATTR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2029",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENUSEATTR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x202a",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYUSESKIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x202b",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRUSESKIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x202c",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENUSESKIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x202d",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYGROUP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x202e",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRGROUP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x202f",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENGROUP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2030",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_TURN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2031",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_TURN_O",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2032",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYHREC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2033",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MORE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2034",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRHANSYA_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2035",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENHANSYA_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2036",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRKYUSYU_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2037",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENKYUSYU_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2038",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRMUKOU_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2039",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENMUKOU_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x203a",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRWEAK_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x203b",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENWEAK_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x203c",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDHP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x203d",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDMP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x203e",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDLV_O",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x203f",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2040",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDBAD_ALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2041",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDHOJO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2042",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDHANSYA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2043",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDKYUSYU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2044",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDMUKOU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2045",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDWEAK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2046",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDUSEATTR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2047",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDUSESKIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2048",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDUSEGROUP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2049",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDHREC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x204a",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDHP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x204b",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDMP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x204c",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDLV_O",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x204d",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x204e",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDBAD_ALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x204f",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDHOJO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2050",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDHANSYA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2051",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDKYUSYU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2052",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDMUKOU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2053",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDWEAK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2054",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDUSEATTR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2055",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDUSESKIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2056",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDUSEGROUP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2057",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDHREC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2058",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2059",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRALLHP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x205a",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENALLHP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x205b",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYABLESKIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x205c",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYATTRSKIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x205d",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ELEMENT_HITSUB",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x205e",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ELEMENT_HIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x205f",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ELEMENT_RESIST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2060",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ELEMENT_NULLIFY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2061",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ANALYZE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2062",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_DOWN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2063",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_SLIP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2064",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENOVERLV",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2065",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_WALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2066",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_NONE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2067",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_AI",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2068",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_HPMIN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2069",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_LVMIN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x206a",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_MPMAX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x206b",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_BAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x206c",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NOTBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x206d",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x206e",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_MINE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x206f",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_MYAI",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2070",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_HANSYA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2071",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_KYUSYU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2072",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_MUKOU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2073",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_WEAK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2074",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NOTHANSYA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2075",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NOTKYUSYU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2076",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NOTMUKOU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2077",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NOTWEAK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2078",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_APPOINT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2079",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_DOWN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x207a",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_STAND",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x207b",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_HANSYA_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x207c",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_KYUSYU_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x207d",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_MUKOU_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x207e",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_WEAK_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x207f",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NOTHANSYA_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2080",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NOTKYUSYU_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2081",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NOTMUKOU_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2082",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NOTWEAK_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2083",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_HERO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2084",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NOTID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2085",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_HOJO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2086",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NOTHOJO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2087",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_AFFINITY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2088",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_DOWN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2089",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_SLIP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x208a",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_DROPITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x208b",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_AFFINITY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x208c",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_FRIDTURN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x208d",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ENIDTURN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x208e",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_FRHOJO_ON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x208f",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_FRHOJO_OFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2090",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ENHOJO_ON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2091",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_FRBAD_ON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2092",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ENBAD_ON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2093",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_FRHP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2094",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_FRLV",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2095",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ENLV",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2096",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_SKILATTR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2097",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_FRCNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x20ef AI_GET_P_NUM"
+    },
+    {
+        "Index":  "0x2098",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNI",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2099",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIHPMIN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x209a",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIWEAK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x209b",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIWEAK_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x209c",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIWEAK_DW",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x209d",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIWEAKHPMIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x209e",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIWEAKHPMIN_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x209f",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIWEAKHPMIN_DW",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20a0",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNINOMALHPMIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20a1",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNINOMALHPMIN_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20a2",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNINOMALHPMIN_DW",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20a3",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIBESTATTRSKIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20a4",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIBESTATTRITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20a5",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIBESTATKSKIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20a6",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIAPPOINT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20a7",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIWEAKATTRSKIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20a8",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIHERO",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20a9",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIATAB",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20aa",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIATAB_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ab",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIATAB_DW",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ac",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNICND_FR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ad",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIHOJO_OFF_FR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ae",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIHOJO_OFF_EN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20af",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNILVMAX_EN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20b0",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNINOMALLVMAXHPMAX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20b1",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNINOMALNOTBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20b2",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNINOTNOMAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20b3",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_MY_ID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20b4",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_P_MAX_HP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20b5",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_P_NOW_HP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20b6",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_NEXT_ID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20b7",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_P_ORDER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20b8",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_P_MAX_SP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20b9",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_P_NOW_SP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ba",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIHOJO_ON_EN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20bb",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIHANSYA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20bc",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIKYUSYU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20bd",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIMUKOU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20be",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIRESIST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20bf",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIWEAKHPMAX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20c0",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIWEAKHPMAX_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20c1",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIWEAKHPMAX_DW",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20c2",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIBADHPMAX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20c3",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIBADHPMIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20c4",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIRANDOM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20c5",
+        "ReturnType":  "int",
+        "Name":  "AI_DEB_PRI_TARUNI_ID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20c6",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ISENEMY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20c7",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_BADSTATUS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20c8",
+        "ReturnType":  "int",
+        "Name":  "AI_CHG_CAMERA_FIX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20c9",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_CAMERA_ANM_S",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ca",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_CAMERA_ANM_E",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20cb",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_CAMERA_ANM_TIME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20cc",
+        "ReturnType":  "int",
+        "Name":  "AI_CHG_CAMERA_ANM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20cd",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_CAMERA_ANM_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ce",
+        "ReturnType":  "void",
+        "Name":  "CALL_BATTLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20cf",
+        "ReturnType":  "void",
+        "Name":  "WAIT_BATTLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20d0",
+        "ReturnType":  "void",
+        "Name":  "BTL_FADE_IN",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20d1",
+        "ReturnType":  "void",
+        "Name":  "BTL_FADE_SYNC",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20d2",
+        "ReturnType":  "int",
+        "Name":  "BTL_CUTSCENE_LOAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20d3",
+        "ReturnType":  "void",
+        "Name":  "BTL_CUTSCENE_LOADSYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20d4",
+        "ReturnType":  "void",
+        "Name":  "BTL_CUTSCENE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20d5",
+        "ReturnType":  "void",
+        "Name":  "BTL_CUTSCENE_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20d6",
+        "ReturnType":  "void",
+        "Name":  "BTL_CUTSCENE_END",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20d7",
+        "ReturnType":  "void",
+        "Name":  "AI_ACT_WAIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20d8",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_PLAYER_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20d9",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20da",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_MYATTRATTACK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20db",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_E_NUM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20dc",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNI_NOANALYZE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20dd",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_UNIHOJO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20de",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENRESIST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20df",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ATTRSKIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20e0",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_BOSS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20e1",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_UNIATTACK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20e2",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_UNIBESTATKSKIL_ALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20e3",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_UNIRESIST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20e4",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_UNIBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20e5",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_UNINOMAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20e6",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_P_ABLE_SKILL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20e7",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ENBADOFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20e8",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNINOBADOFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20e9",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_UNIHP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ea",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDABLESKIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20eb",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYRESIST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ec",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYHOJO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ed",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_FIRST_ACTION",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ee",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_GLOBAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ef",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_P_NUM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  "Alias of 0x2097 AI_GET_FRCNT"
+    },
+    {
+        "Index":  "0x20f0",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_ASSISTSKILL_MODE",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20f1",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRALLSP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20f2",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_GLOBAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20f3",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_CAMERA_END",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20f4",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNI_TALKCHARA",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20f5",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ID_PSTOCK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20f6",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALKRESULT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20f7",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_CAMERA_FOV_S",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20f8",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_CAMERA_ROTANM_S",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20f9",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_CAMERA_ROTANM_E",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20fa",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_CAMERA_RESET",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20fb",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_CAMERA_FOV_E",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20fc",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ID_TALKCHARA",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20fd",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_IDLV",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20fe",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_CAMERA_SHAKE_S",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x20ff",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_CAMERA_SHAKE_E",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2100",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_PBOOK_REGIST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2101",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ID_TALK_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2102",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ID_TALK_PERSON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2103",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ID_TALK_MONEYMIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2104",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ID_TALK_MONEYMAX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2105",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ID_TALK_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2106",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ID_TALK_ITEM_RARE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2107",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALK_SPEAKER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2108",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_ADD_FACEANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2109",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_GLOBAL_EVENT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x210a",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_GLOBAL_EVENT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x210b",
+        "ReturnType":  "int",
+        "Name":  "BTL_CUTSCENE_LOAD_TALK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x210c",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_LOCAL_PARAM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x210d",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_LOCAL_PARAM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x210e",
+        "ReturnType":  "void",
+        "Name":  "BTL_CUTSCENE_CANCEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x210f",
+        "ReturnType":  "void",
+        "Name":  "AI_ACT_WAIT3",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2110",
+        "ReturnType":  "void",
+        "Name":  "BTL_CUTSCENE_REMOVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2111",
+        "ReturnType":  "void",
+        "Name":  "BTL_RELOCATION",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2112",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ID_FRTARGET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2113",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_UID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2114",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_ENIDAFFINITY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2115",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ENIDAFFINITY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2116",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ABLEWEAK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2117",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_TAKEOVER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2118",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_TAKEOVER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2119",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_ENID_MAXSERIAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x211a",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ENID_MAXSERIAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x211b",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ENID_CURRENTSERIAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x211c",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALKCUTSCENE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x211d",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALKMESS_SCENE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x211e",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALKMESS_WAIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x211f",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALKMESS_PARAM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2120",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALKMESS_EN_PARAM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2121",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALKMESS_STATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2122",
+        "ReturnType":  "void",
+        "Name":  "CALL_EVENTBATTLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2123",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALKMESS_OBTAIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2124",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_TALKMESS_INFODATA",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2125",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALKMESS_MASK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2126",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALKMESS_DOUBLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2127",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_TALKMESS_CRITICAL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2128",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_TALKMESS_SURRENDER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2129",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALKMESS_COOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x212a",
+        "ReturnType":  "void",
+        "Name":  "BTL_CUTSCENE_CAPTURE_ENDFRAME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x212b",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_UNIANALYZE_OPEN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x212c",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_GUN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x212d",
+        "ReturnType":  "void",
+        "Name":  "AI_ACT_GUN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x212e",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_HIGHSKILL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x212f",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_REZ",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2130",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_BADSTATE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2131",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_BOSS_PRESIDENT_SUMMON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2132",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_TURN_EQUAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2133",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_TURN_DIVI",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2134",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_NOTMYBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2135",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_NOTFRBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2136",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_NOTENBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2137",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_NOTMYHOJO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2138",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_NOTFRHOJO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2139",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_NOTENHOJO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x213a",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_PREV_ATK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x213b",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_PREV_WAIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x213c",
+        "ReturnType":  "void",
+        "Name":  "BTL_SYSTEM_MESS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x213d",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_EXTENDEDWAIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x213e",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENEMY_ABLEWEAK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x213f",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_ENTAKEOVER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2140",
+        "ReturnType":  "int",
+        "Name":  "BTL_ROULETTE_BET",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2141",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UIDTOID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2142",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ENHP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2143",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENALLDOWN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2144",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_BOSSDAMAGE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2145",
+        "ReturnType":  "void",
+        "Name":  "AI_CLEAR_BOSSDAMAGE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2146",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ACTUID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2147",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_VOICE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2148",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNI_DARK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2149",
+        "ReturnType":  "void",
+        "Name":  "BTL_ADD_SERIES",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x214a",
+        "ReturnType":  "int",
+        "Name":  "BTL_GET_SERIES",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x214b",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ID_TALK_FLAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x214c",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALK_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x214d",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_TALK_ITEM_RARE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x214e",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_DEBUFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x214f",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_UNKNOWN_ATTR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2150",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_TALK_MAJOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2151",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_EXCEPTION",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2152",
+        "ReturnType":  "void",
+        "Name":  "BTL_REQ_ASSIST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2153",
+        "ReturnType":  "void",
+        "Name":  "BTL_CLS_ASSIST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2154",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ROUNDUP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2155",
+        "ReturnType":  "void",
+        "Name":  "AI_SET_MSGVAR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2156",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIHPMIN_EN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2157",
+        "ReturnType":  "void",
+        "Name":  "AI_ACT_ESCAPE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2158",
+        "ReturnType":  "int",
+        "Name":  "BTL_CHK_ENCOUNTFLAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2159",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNI_SKIMMING",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x215a",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNI_TALKCONTACT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x215b",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_FRID_MAXSERIAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x215c",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_FRID_MAXSERIAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x215d",
+        "ReturnType":  "void",
+        "Name":  "AI_ACT_DEFENSE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x215e",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_FIXED",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x215f",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_HEAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2160",
+        "ReturnType":  "void",
+        "Name":  "BTL_TALK_ADDWANTED",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2161",
+        "ReturnType":  "int",
+        "Name":  "BTL_TALK_PERSONAGET_LOADREQ",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2162",
+        "ReturnType":  "int",
+        "Name":  "BTL_TALK_PERSONAGET_LOADWAIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2163",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_GUARDORDER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2164",
+        "ReturnType":  "int",
+        "Name":  "AI_SET_GUARDORDER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2165",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNI_ATTACK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2166",
+        "ReturnType":  "int",
+        "Name":  "BTL_CHK_DUNGEONMATCH",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2167",
+        "ReturnType":  "int",
+        "Name":  "BTL_SET_STARTDUNGEONMATCH",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2168",
+        "ReturnType":  "int",
+        "Name":  "BTL_WAIT_DUNGEONMATCH",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2169",
+        "ReturnType":  "void",
+        "Name":  "AI_ENID_SUSPEND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x216a",
+        "ReturnType":  "void",
+        "Name":  "AI_ENID_RESUME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x216b",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_EXCEPT_ENCOUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x216c",
+        "ReturnType":  "void",
+        "Name":  "AI_FRID_SUSPEND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x216d",
+        "ReturnType":  "void",
+        "Name":  "AI_FRID_RESUME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x216e",
+        "ReturnType":  "int",
+        "Name":  "BTL_TALK_WEATHER_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x216f",
+        "ReturnType":  "int",
+        "Name":  "BTL_TALK_CHECK_NO_YOU",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2170",
+        "ReturnType":  "int",
+        "Name":  "BTL_TALK_NO_YOU",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2171",
+        "ReturnType":  "void",
+        "Name":  "PREPARE_FIELDBATTLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2172",
+        "ReturnType":  "void",
+        "Name":  "CALL_FIELDBATTLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2173",
+        "ReturnType":  "int",
+        "Name":  "BTL_TALK_ICON_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2174",
+        "ReturnType":  "void",
+        "Name":  "BTL_SET_MSG_SPEAKER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2175",
+        "ReturnType":  "int",
+        "Name":  "BTL_TALK_GET_SELECTNO",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2176",
+        "ReturnType":  "void",
+        "Name":  "BTL_BOSSSE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2177",
+        "ReturnType":  "int",
+        "Name":  "BTL_TALK_SET_RESETCAMERA",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2178",
+        "ReturnType":  "int",
+        "Name":  "BTL_TALK_SET_ASSIST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2179",
+        "ReturnType":  "void",
+        "Name":  "BTL_CUTSCENE_BOSS999_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x217a",
+        "ReturnType":  "int",
+        "Name":  "BTL_TALK_GET_YOSHIDACOOP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x217b",
+        "ReturnType":  "int",
+        "Name":  "BTL_TALK_CHK_USONAKI",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x217c",
+        "ReturnType":  "void",
+        "Name":  "BTL_MISSION_ADD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x217d",
+        "ReturnType":  "void",
+        "Name":  "BTL_MISSION_REMOVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x217e",
+        "ReturnType":  "void",
+        "Name":  "BTL_LETTERBOX_IN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x217f",
+        "ReturnType":  "void",
+        "Name":  "BTL_LETTERBOX_OUT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2180",
+        "ReturnType":  "int",
+        "Name":  "BTL_CHK_NOTPHYSICAL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2181",
+        "ReturnType":  "void",
+        "Name":  "BTL_ROULETTE_BET_LOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2182",
+        "ReturnType":  "void",
+        "Name":  "AI_ACT_DANGERUP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2183",
+        "ReturnType":  "void",
+        "Name":  "BTL_SYNC_ASSIST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2184",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_TECHNICAL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2185",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_HPMAX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2186",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FMTPINCH",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2187",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ID_ENTARGET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2188",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UID_IDBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2189",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UID_IDSUPPORT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x218a",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UID_IDNOTBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x218b",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UID_IDNOTSUPPORT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x218c",
+        "ReturnType":  "int",
+        "Name":  "BTL_CUTIN_CREATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x218d",
+        "ReturnType":  "int",
+        "Name":  "BTL_CUTIN_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x218e",
+        "ReturnType":  "int",
+        "Name":  "BTL_CUTIN_START",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x218f",
+        "ReturnType":  "int",
+        "Name":  "BTL_CUTIN_START_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2190",
+        "ReturnType":  "int",
+        "Name":  "BTL_CUTIN_END_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2191",
+        "ReturnType":  "int",
+        "Name":  "BTL_CUTIN_DELETE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2192",
+        "ReturnType":  "int",
+        "Name":  "BTL_TALK_EXIST_BLANK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2193",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ENTALK_ITEM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2194",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ENTALK_MONEY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2195",
+        "ReturnType":  "void",
+        "Name":  "BTL_TALK_ALLY_SPEAKER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2196",
+        "ReturnType":  "void",
+        "Name":  "AI_ADD_REINFORCEMENT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2197",
+        "ReturnType":  "void",
+        "Name":  "BTL_TALK_REQ_JYOKYO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2198",
+        "ReturnType":  "void",
+        "Name":  "BTL_TALK_REQ_SKILLNAME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x2199",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_ATTACK_WEAK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x219a",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_DEATHMARCH",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x219b",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRHOJO2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x219c",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENHOJO2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x219d",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDHOJO2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x219e",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ENIDHOJO2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x219f",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_HOJO2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21a0",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NOTHOJO2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21a1",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_FRHOJO2_ON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21a2",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_FRHOJO2_OFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21a3",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_ENHOJO2_ON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21a4",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIHOJO2_OFF_FR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21a5",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIHOJO2_OFF_EN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21a6",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_UNIHOJO2_ON_EN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21a7",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_UNIHOJO2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21a8",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYHOJO2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21a9",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_NOTMYHOJO2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21aa",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_NOTFRHOJO2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21ab",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_NOTENHOJO2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21ac",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_MYUNSTABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21ad",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_UNSTABLE_UID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21ae",
+        "ReturnType":  "int",
+        "Name":  "BTL_GET_CURRENT_CHARAID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21af",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_FRIDTECH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21b0",
+        "ReturnType":  "int",
+        "Name":  "AI_GET_BULLET",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21b1",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_UNSTABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21b2",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NUNSTABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21b3",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_HOUMA",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21b4",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_NHOUMA",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21b5",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_UNSTABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21b6",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_HOUMA",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21b7",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_UNSTABLE_BAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21b8",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_UNSTABLE_NBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21b9",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_UNSTABLE_BAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21ba",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_UNSTABLE_NBAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21bb",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_GUN_KILL_EN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21bc",
+        "ReturnType":  "int",
+        "Name":  "AI_TAR_GUN_KILL_EN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21bd",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_SP_ATTACK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21be",
+        "ReturnType":  "void",
+        "Name":  "AI_ACT_SP_ATTACK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21bf",
+        "ReturnType":  "int",
+        "Name":  "BTL_GET_CHALLENGE_REWARD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21c0",
+        "ReturnType":  "void",
+        "Name":  "BTL_REQ_ASSIST_SEQ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21c1",
+        "ReturnType":  "int",
+        "Name":  "AI_ACT_BADSKILL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21c2",
+        "ReturnType":  "int",
+        "Name":  "AI_CHK_ID_STRONG_FLAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21c3",
+        "ReturnType":  "int",
+        "Name":  "BTL_GET_CHALLENGE_MODE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21c4",
+        "ReturnType":  "int",
+        "Name":  "BTL_GET_CHALLENGE_NUMBER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21c5",
+        "ReturnType":  "int",
+        "Name":  "BTL_GET_CHALLENGE_REWARD_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21c6",
+        "ReturnType":  "int",
+        "Name":  "BTL_GER_TALK_ABI_MEMBER_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21c7",
+        "ReturnType":  "void",
+        "Name":  "BTL_ITEM_STORAGE_SAVE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21c8",
+        "ReturnType":  "void",
+        "Name":  "BTL_ITEM_STORAGE_LOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21c9",
+        "ReturnType":  "void",
+        "Name":  "BTL_ITEM_STORAGE_CLEAR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21ca",
+        "ReturnType":  "int",
+        "Name":  "BTL_ITEM_STORAGE_CHECK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21cb",
+        "ReturnType":  "void",
+        "Name":  "AI_CANCEL_GUARDORDER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x21cc",
+        "ReturnType":  "int",
+        "Name":  "BTL_GET_ASSIST_PC_ID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    }
+]

--- a/Source/AtlusScriptLibrary/Libraries/Persona5Royal/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona5Royal/Modules/Common/Functions.json
@@ -1,0 +1,6561 @@
+[
+    {
+        "Index":  "0x0000",
+        "ReturnType":  "void",
+        "Name":  "SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0001",
+        "ReturnType":  "void",
+        "Name":  "WAIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0002",
+        "ReturnType":  "void",
+        "Name":  "PUT",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0003",
+        "ReturnType":  "void",
+        "Name":  "PUTS",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "string",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0004",
+        "ReturnType":  "void",
+        "Name":  "PUTF",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0005",
+        "ReturnType":  "void",
+        "Name":  "MSG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0006",
+        "ReturnType":  "void",
+        "Name":  "NULL",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0007",
+        "ReturnType":  "void",
+        "Name":  "FADEIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0008",
+        "ReturnType":  "void",
+        "Name":  "FADEOUT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0009",
+        "ReturnType":  "void",
+        "Name":  "FADEEND_CHECK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x000a",
+        "ReturnType":  "void",
+        "Name":  "FADE_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x000b",
+        "ReturnType":  "void",
+        "Name":  "FADE_COLOR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x000c",
+        "ReturnType":  "int",
+        "Name":  "BIT_CHK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x000d",
+        "ReturnType":  "void",
+        "Name":  "BIT_ON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x000e",
+        "ReturnType":  "void",
+        "Name":  "BIT_OFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x000f",
+        "ReturnType":  "int",
+        "Name":  "GET_COUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0010",
+        "ReturnType":  "void",
+        "Name":  "SET_COUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0011",
+        "ReturnType":  "int",
+        "Name":  "RND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0012",
+        "ReturnType":  "void",
+        "Name":  "LIFESIM_SET_IMAGE",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0013",
+        "ReturnType":  "void",
+        "Name":  "MDL_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0014",
+        "ReturnType":  "void",
+        "Name":  "LIFESIM_SHOW_BUSTUP",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0015",
+        "ReturnType":  "void",
+        "Name":  "LIFESIM_HIDE_BUSTUP",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0016",
+        "ReturnType":  "void",
+        "Name":  "LIFESIM_MOUSEANIM_ENABLE",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0017",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x11e4 FLD_MODEL_ANIM"
+    },
+    {
+        "Index":  "0x0018",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x11e5 FLD_MODEL_ANIM_SYNC"
+    },
+    {
+        "Index":  "0x0019",
+        "ReturnType":  "void",
+        "Name":  "CALL_CALENDAR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x001a",
+        "ReturnType":  "void",
+        "Name":  "SET_NEXT_DAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x001b",
+        "ReturnType":  "int",
+        "Name":  "GET_DAY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x001c",
+        "ReturnType":  "int",
+        "Name":  "GET_TIME",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x001d",
+        "ReturnType":  "int",
+        "Name":  "CHK_DAYS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x001e",
+        "ReturnType":  "int",
+        "Name":  "GET_DAYOFWEEK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x001f",
+        "ReturnType":  "void",
+        "Name":  "SCENE_CHANGE_WAIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0020",
+        "ReturnType":  "void",
+        "Name":  "MOVIE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0021",
+        "ReturnType":  "void",
+        "Name":  "MOVIE_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0022",
+        "ReturnType":  "void",
+        "Name":  "MSG_WND_DSP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0023",
+        "ReturnType":  "void",
+        "Name":  "MSG_WND_CLS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0024",
+        "ReturnType":  "int",
+        "Name":  "SEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0025",
+        "ReturnType":  "void",
+        "Name":  "SEL_WND_DSP",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0026",
+        "ReturnType":  "void",
+        "Name":  "SEL_WND_CLS",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0027",
+        "ReturnType":  "void",
+        "Name":  "SET_MSG_VAR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0028",
+        "ReturnType":  "void",
+        "Name":  "SEL_DEFKEY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0029",
+        "ReturnType":  "void",
+        "Name":  "SEL_MASK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x002a",
+        "ReturnType":  "void",
+        "Name":  "MSG_SYSTEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x002b",
+        "ReturnType":  "int",
+        "Name":  "CAMERA_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x002c",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_READ_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x1046 FLD_CAMERA_READ_SYNC"
+    },
+    {
+        "Index":  "0x002d",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_FREE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x002e",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_SET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x1048 FLD_CAMERA_SET"
+    },
+    {
+        "Index":  "0x002f",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_RESET",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  "Alias of 0x1049 FLD_CAMERA_RESET"
+    },
+    {
+        "Index":  "0x0030",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x104a FLD_CAMERA_ANIM"
+    },
+    {
+        "Index":  "0x0031",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_ANIM_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x104b FLD_CAMERA_ANIM_SYNC"
+    },
+    {
+        "Index":  "0x0032",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM_SEEK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0033",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM_FRAMESYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0034",
+        "ReturnType":  "void",
+        "Name":  "MDL_SET_SCALE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0035",
+        "ReturnType":  "int",
+        "Name":  "ADD_PC_MONEY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0036",
+        "ReturnType":  "int",
+        "Name":  "GET_SMN_LEVEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0037",
+        "ReturnType":  "int",
+        "Name":  "GET_HP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0038",
+        "ReturnType":  "int",
+        "Name":  "GET_MAXHP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0039",
+        "ReturnType":  "void",
+        "Name":  "SET_HP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x003a",
+        "ReturnType":  "int",
+        "Name":  "GET_SP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x003b",
+        "ReturnType":  "int",
+        "Name":  "GET_MAXSP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x003c",
+        "ReturnType":  "void",
+        "Name":  "SET_SP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x003d",
+        "ReturnType":  "int",
+        "Name":  "GET_ITEM_NUM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x003e",
+        "ReturnType":  "void",
+        "Name":  "SET_ITEM_NUM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x003f",
+        "ReturnType":  "int",
+        "Name":  "GET_EQUIP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0040",
+        "ReturnType":  "void",
+        "Name":  "SET_EQUIP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0041",
+        "ReturnType":  "void",
+        "Name":  "PARTY_IN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0042",
+        "ReturnType":  "void",
+        "Name":  "PARTY_OUT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0043",
+        "ReturnType":  "int",
+        "Name":  "GET_PARTY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0044",
+        "ReturnType":  "void",
+        "Name":  "RECOVERY_ALL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0045",
+        "ReturnType":  "int",
+        "Name":  "GET_AND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0046",
+        "ReturnType":  "int",
+        "Name":  "GET_OR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0047",
+        "ReturnType":  "int",
+        "Name":  "GET_XOR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0048",
+        "ReturnType":  "int",
+        "Name":  "GET_L_SHIFT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0049",
+        "ReturnType":  "int",
+        "Name":  "GET_R_SHIFT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x004a",
+        "ReturnType":  "int",
+        "Name":  "REM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x004b",
+        "ReturnType":  "int",
+        "Name":  "SCRIPT_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x004c",
+        "ReturnType":  "void",
+        "Name":  "SCRIPT_READ_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x104d FLD_SCRIPT_READ_SYNC"
+    },
+    {
+        "Index":  "0x004d",
+        "ReturnType":  "void",
+        "Name":  "SCRIPT_FREE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x004e",
+        "ReturnType":  "void",
+        "Name":  "SCRIPT_EXEC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x004f",
+        "ReturnType":  "int",
+        "Name":  "SCRIPT_SEARCH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0050",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_SET_HELPERPOS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x1051 FLD_CAMERA_SET_HELPERPOS"
+    },
+    {
+        "Index":  "0x0051",
+        "ReturnType":  "void",
+        "Name":  "RUMBLE_START_L",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0052",
+        "ReturnType":  "void",
+        "Name":  "RUMBLE_STOP_L",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0053",
+        "ReturnType":  "void",
+        "Name":  "RUMBLE_START_S",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0054",
+        "ReturnType":  "void",
+        "Name":  "RUMBLE_STOP_S",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0055",
+        "ReturnType":  "void",
+        "Name":  "RUMBLE_STOP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  "Alias of 0x0056 RUMBLE_CHECK"
+    },
+    {
+        "Index":  "0x0056",
+        "ReturnType":  "void",
+        "Name":  "RUMBLE_CHECK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  "Alias of 0x0055 RUMBLE_STOP"
+    },
+    {
+        "Index":  "0x0057",
+        "ReturnType":  "int",
+        "Name":  "CHK_DAYS_STARTEND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0058",
+        "ReturnType":  "void",
+        "Name":  "SAVE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0059",
+        "ReturnType":  "int",
+        "Name":  "SAVE_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x005a",
+        "ReturnType":  "void",
+        "Name":  "SAVE_MENU",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x005b",
+        "ReturnType":  "void",
+        "Name":  "SAVE_MENU_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x005c",
+        "ReturnType":  "void",
+        "Name":  "BGM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x005d",
+        "ReturnType":  "void",
+        "Name":  "PAD_TRIG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x005e",
+        "ReturnType":  "void",
+        "Name":  "PAD_PRESS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x005f",
+        "ReturnType":  "int",
+        "Name":  "MSG_SELECT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0060",
+        "ReturnType":  "void",
+        "Name":  "MSG_TUTORIAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0061",
+        "ReturnType":  "void",
+        "Name":  "DATE_DISP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0062",
+        "ReturnType":  "void",
+        "Name":  "BGM_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0063",
+        "ReturnType":  "void",
+        "Name":  "SET_DBG_DAY",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0064",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM_SPEED",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0065",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM_NEXT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0066",
+        "ReturnType":  "int",
+        "Name":  "MDL_ICON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0067",
+        "ReturnType":  "int",
+        "Name":  "GET_PC_PARAM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0068",
+        "ReturnType":  "int",
+        "Name":  "GET_PC_PARAM_LV",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0069",
+        "ReturnType":  "void",
+        "Name":  "DBG_SET_PC_PARAM",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x006a",
+        "ReturnType":  "void",
+        "Name":  "UPDATE_ENQUETE",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x006b",
+        "ReturnType":  "void",
+        "Name":  "DBG_PUT",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x006c",
+        "ReturnType":  "void",
+        "Name":  "ADD_PC_PARAM_SYNC",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x006d",
+        "ReturnType":  "void",
+        "Name":  "SET_SUSPICION",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x006e",
+        "ReturnType":  "void",
+        "Name":  "ADD_SUSPICION_START",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x006f",
+        "ReturnType":  "void",
+        "Name":  "ADD_SUSPICION_SYNC",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0070",
+        "ReturnType":  "void",
+        "Name":  "GET_SUSPICION",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0071",
+        "ReturnType":  "void",
+        "Name":  "GET_SUSPICION_LV",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0072",
+        "ReturnType":  "void",
+        "Name":  "DBG_SCRIPT_MENU",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0073",
+        "ReturnType":  "int",
+        "Name":  "GET_TOTAL_DAY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0074",
+        "ReturnType":  "int",
+        "Name":  "GET_MONTH",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0075",
+        "ReturnType":  "int",
+        "Name":  "GET_WEATHER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0076",
+        "ReturnType":  "int",
+        "Name":  "GET_MOON_AGE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0077",
+        "ReturnType":  "void",
+        "Name":  "ADD_SUSPICION",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0078",
+        "ReturnType":  "void",
+        "Name":  "DISP_CAUTION",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0079",
+        "ReturnType":  "int",
+        "Name":  "PAD_CHK_TRIG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x007a",
+        "ReturnType":  "int",
+        "Name":  "PAD_CHK_PRESS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x007b",
+        "ReturnType":  "void",
+        "Name":  "EVERY_MORNING_NETWORK",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x007c",
+        "ReturnType":  "void",
+        "Name":  "ZEAL_TEX_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x007d",
+        "ReturnType":  "void",
+        "Name":  "ZEAL_TEX_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x007e",
+        "ReturnType":  "void",
+        "Name":  "ZEAL_TEX_DISP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x007f",
+        "ReturnType":  "void",
+        "Name":  "ZEAL_TEX_FREE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0080",
+        "ReturnType":  "void",
+        "Name":  "BGENV_SE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0081",
+        "ReturnType":  "void",
+        "Name":  "BGENV_SE_FADEOUT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0082",
+        "ReturnType":  "void",
+        "Name":  "BGENV_SE_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0083",
+        "ReturnType":  "int",
+        "Name":  "BGENV_SE_CHECK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0084",
+        "ReturnType":  "void",
+        "Name":  "MESSAGE_REF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0085",
+        "ReturnType":  "void",
+        "Name":  "MSG_CAPTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0086",
+        "ReturnType":  "void",
+        "Name":  "MSG_MIND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0087",
+        "ReturnType":  "void",
+        "Name":  "SET_SUSPICION_LV",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0088",
+        "ReturnType":  "void",
+        "Name":  "COMSE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0089",
+        "ReturnType":  "void",
+        "Name":  "COMSE_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x008a",
+        "ReturnType":  "void",
+        "Name":  "LOGICTREE_OPEN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x008b",
+        "ReturnType":  "void",
+        "Name":  "LOGICTREE_OPEN_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x008c",
+        "ReturnType":  "void",
+        "Name":  "LOGICTREE_CLOSE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x008d",
+        "ReturnType":  "void",
+        "Name":  "LOGICTREE_CLOSE_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x008e",
+        "ReturnType":  "void",
+        "Name":  "LOGICTREE_SET_BRANCH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x008f",
+        "ReturnType":  "void",
+        "Name":  "LOGICTREE_RESET_BRANCH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0090",
+        "ReturnType":  "void",
+        "Name":  "LOGICTREE_CLEAR_BRANCH",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0091",
+        "ReturnType":  "int",
+        "Name":  "MDL_GET_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0092",
+        "ReturnType":  "void",
+        "Name":  "CHAT_WND_DSP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0093",
+        "ReturnType":  "void",
+        "Name":  "CHAT_WND_CLS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0094",
+        "ReturnType":  "void",
+        "Name":  "MSG_TREE_SET_ROOT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0095",
+        "ReturnType":  "void",
+        "Name":  "MSG_TREE_SET_NODE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param7",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0096",
+        "ReturnType":  "void",
+        "Name":  "MSG_TREE_OPEN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0097",
+        "ReturnType":  "int",
+        "Name":  "MSG_TREE_GET_MISS_COUNT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0098",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_QUAKE_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0099",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_QUAKE_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x009a",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM_BLENDSYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x009b",
+        "ReturnType":  "void",
+        "Name":  "TIMER_SETUP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x009c",
+        "ReturnType":  "void",
+        "Name":  "TIMER_SETUP_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x009d",
+        "ReturnType":  "void",
+        "Name":  "TIMER_DESTROY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x009e",
+        "ReturnType":  "void",
+        "Name":  "TIMER_SET_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x009f",
+        "ReturnType":  "int",
+        "Name":  "TIMER_GET_VISIBLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00a0",
+        "ReturnType":  "void",
+        "Name":  "TIMER_SET_PAUSE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00a1",
+        "ReturnType":  "int",
+        "Name":  "TIMER_GET_PAUSE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00a2",
+        "ReturnType":  "void",
+        "Name":  "TIMER_SET_TIME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00a3",
+        "ReturnType":  "void",
+        "Name":  "TIMER_ADD_TIME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00a4",
+        "ReturnType":  "int",
+        "Name":  "TIMER_GET_TIME",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00a5",
+        "ReturnType":  "int",
+        "Name":  "MDL_GET_ITEM_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00a6",
+        "ReturnType":  "void",
+        "Name":  "MDL_ADD_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00a7",
+        "ReturnType":  "void",
+        "Name":  "MDL_ADD_ANIM_NEXT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00a8",
+        "ReturnType":  "void",
+        "Name":  "MDL_ADD_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00a9",
+        "ReturnType":  "int",
+        "Name":  "SEL_TIME_LIMIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00aa",
+        "ReturnType":  "int",
+        "Name":  "MDL_GET_ANIM_COUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ab",
+        "ReturnType":  "void",
+        "Name":  "MSG_WND_SET_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ac",
+        "ReturnType":  "void",
+        "Name":  "MSG_WND_RESET_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ad",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_SHAKE_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ae",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_SHAKE_PAUSE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00af",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_SHAKE_STOP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00b0",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_SHAKE_SCALE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00b1",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_SHAKE_SPEED",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00b2",
+        "ReturnType":  "int",
+        "Name":  "ANALOG_ASTICK_CHECK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00b3",
+        "ReturnType":  "void",
+        "Name":  "MDL_TRACK_ADD_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00b4",
+        "ReturnType":  "void",
+        "Name":  "MDL_TRACK_ADD_ANIM_NEXT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00b5",
+        "ReturnType":  "void",
+        "Name":  "MDL_TRACK_ADD_ANIM_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00b6",
+        "ReturnType":  "float",
+        "Name":  "SIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00b7",
+        "ReturnType":  "float",
+        "Name":  "COS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00b8",
+        "ReturnType":  "float",
+        "Name":  "TAN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00b9",
+        "ReturnType":  "float",
+        "Name":  "ASIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ba",
+        "ReturnType":  "float",
+        "Name":  "ACOS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00bb",
+        "ReturnType":  "float",
+        "Name":  "ATAN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00bc",
+        "ReturnType":  "float",
+        "Name":  "ATAN2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00bd",
+        "ReturnType":  "float",
+        "Name":  "SQRT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00be",
+        "ReturnType":  "void",
+        "Name":  "PUSH_UNIFORM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00bf",
+        "ReturnType":  "void",
+        "Name":  "POP_UNIFORM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00c0",
+        "ReturnType":  "void",
+        "Name":  "CLEAR_UNIFORM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00c1",
+        "ReturnType":  "void",
+        "Name":  "PUSH_WEATHER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00c2",
+        "ReturnType":  "void",
+        "Name":  "POP_WEATHER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00c3",
+        "ReturnType":  "void",
+        "Name":  "CLEAR_WEATHER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00c4",
+        "ReturnType":  "void",
+        "Name":  "BGENV_SE_PLAY_CUEID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00c5",
+        "ReturnType":  "void",
+        "Name":  "BGENV_SE_FADEOUT_CUEID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00c6",
+        "ReturnType":  "void",
+        "Name":  "BGENV_SE_STOP_CUEID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00c7",
+        "ReturnType":  "int",
+        "Name":  "BGENV_SE_CHECK_CUEID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00c8",
+        "ReturnType":  "void",
+        "Name":  "SKILL_ADD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00c9",
+        "ReturnType":  "void",
+        "Name":  "SKILL_ADD_CMM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ca",
+        "ReturnType":  "int",
+        "Name":  "FRIEND_SKILL_ADD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00cb",
+        "ReturnType":  "int",
+        "Name":  "CHK_FRIEND_SKILL_ADD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00cc",
+        "ReturnType":  "int",
+        "Name":  "NEXT_SKILL_ADD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00cd",
+        "ReturnType":  "int",
+        "Name":  "CHK_NEXT_SKILL_ADD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ce",
+        "ReturnType":  "void",
+        "Name":  "TEST_TEX_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00cf",
+        "ReturnType":  "void",
+        "Name":  "TEST_TEX_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00d0",
+        "ReturnType":  "void",
+        "Name":  "TEST_TEX_DISP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00d1",
+        "ReturnType":  "void",
+        "Name":  "TEST_TEX_FREE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00d2",
+        "ReturnType":  "int",
+        "Name":  "GET_MONTH_TOTAL_DAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00d3",
+        "ReturnType":  "int",
+        "Name":  "GET_DAY_TOTAL_DAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00d4",
+        "ReturnType":  "void",
+        "Name":  "BIT_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00d5",
+        "ReturnType":  "int",
+        "Name":  "GET_WEATHER_DETAIL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00d6",
+        "ReturnType":  "void",
+        "Name":  "SET_HUMAN_LV",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00d7",
+        "ReturnType":  "void",
+        "Name":  "SET_PERSONA_LV",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00d8",
+        "ReturnType":  "void",
+        "Name":  "CLEAR_PERSONA_STOCK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00d9",
+        "ReturnType":  "void",
+        "Name":  "ADD_PERSONA_STOCK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00da",
+        "ReturnType":  "void",
+        "Name":  "ADD_PC_ALL_PARAM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00db",
+        "ReturnType":  "void",
+        "Name":  "SKILL_ADD_ARSENE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00dc",
+        "ReturnType":  "int",
+        "Name":  "MDL_GET_MAJOR_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00dd",
+        "ReturnType":  "int",
+        "Name":  "MDL_GET_MINOR_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00de",
+        "ReturnType":  "int",
+        "Name":  "MDL_GET_SUB_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00df",
+        "ReturnType":  "void",
+        "Name":  "ADD_MAIN_PERSONA_PARAM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00e0",
+        "ReturnType":  "int",
+        "Name":  "GET_MAIN_PERSONA_PARAM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00e1",
+        "ReturnType":  "void",
+        "Name":  "ADD_EQUIP_PERSONA_PARAM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00e2",
+        "ReturnType":  "void",
+        "Name":  "ADD_EQUIP_PERSONA_PARAM_INC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00e3",
+        "ReturnType":  "int",
+        "Name":  "GET_EQUIP_PERSONA_PARAM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00e4",
+        "ReturnType":  "void",
+        "Name":  "KTAI_MENU_START",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00e5",
+        "ReturnType":  "void",
+        "Name":  "KTAI_MENU_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00e6",
+        "ReturnType":  "void",
+        "Name":  "KTAI_MENU_FADE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00e7",
+        "ReturnType":  "void",
+        "Name":  "KTAI_MENU_FADE_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00e8",
+        "ReturnType":  "int",
+        "Name":  "KTAI_MENU_GET_PAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00e9",
+        "ReturnType":  "void",
+        "Name":  "KTAI_MENU_EXIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ea",
+        "ReturnType":  "void",
+        "Name":  "DBG_PUTS",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "string",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00eb",
+        "ReturnType":  "float",
+        "Name":  "GET_MAX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ec",
+        "ReturnType":  "float",
+        "Name":  "GET_MIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ed",
+        "ReturnType":  "void",
+        "Name":  "ADD_PERSONA_SKILL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ee",
+        "ReturnType":  "void",
+        "Name":  "REMOVE_PERSONA_SKILL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ef",
+        "ReturnType":  "void",
+        "Name":  "BGENV_SE_PLAY_CUEID_ALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00f0",
+        "ReturnType":  "void",
+        "Name":  "BGENV_SE_FADEOUT_CUEID_ALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00f1",
+        "ReturnType":  "void",
+        "Name":  "BGENV_SE_STOP_CUEID_ALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00f2",
+        "ReturnType":  "void",
+        "Name":  "SND_VOICE_FACILITY_SETUP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00f3",
+        "ReturnType":  "void",
+        "Name":  "SND_VOICE_FACILITY_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00f4",
+        "ReturnType":  "void",
+        "Name":  "BGENV_LINK_BGOBJ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00f5",
+        "ReturnType":  "void",
+        "Name":  "BGENV_UNLINK_BGOBJ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00f6",
+        "ReturnType":  "int",
+        "Name":  "NPC_BIT_CHK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00f7",
+        "ReturnType":  "void",
+        "Name":  "NPC_BIT_ON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00f8",
+        "ReturnType":  "void",
+        "Name":  "NPC_BIT_OFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00f9",
+        "ReturnType":  "void",
+        "Name":  "ADD_MAXHP_UP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00fa",
+        "ReturnType":  "int",
+        "Name":  "GET_MAXHP_UP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00fb",
+        "ReturnType":  "void",
+        "Name":  "ADD_MAXSP_UP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00fc",
+        "ReturnType":  "int",
+        "Name":  "GET_MAXSP_UP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00fd",
+        "ReturnType":  "void",
+        "Name":  "BGENV_LINE_SE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00fe",
+        "ReturnType":  "void",
+        "Name":  "BGENV_LINE_SE_FADEOUT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x00ff",
+        "ReturnType":  "void",
+        "Name":  "BGENV_LINE_SE_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0100",
+        "ReturnType":  "int",
+        "Name":  "BGENV_LINE_SE_CHECK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0101",
+        "ReturnType":  "void",
+        "Name":  "BGENV_DEF_SE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0102",
+        "ReturnType":  "void",
+        "Name":  "BGENV_DEF_SE_FADEOUT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0103",
+        "ReturnType":  "void",
+        "Name":  "BGENV_DEF_SE_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0104",
+        "ReturnType":  "int",
+        "Name":  "BGENV_DEF_SE_CHECK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0105",
+        "ReturnType":  "int",
+        "Name":  "NPC_EXIST_VALUE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0106",
+        "ReturnType":  "int",
+        "Name":  "NPC_EXIST_VALUE_MD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0107",
+        "ReturnType":  "int",
+        "Name":  "NPC_QUEST_GET_NUM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0108",
+        "ReturnType":  "int",
+        "Name":  "NPC_QUEST_GET_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0109",
+        "ReturnType":  "int",
+        "Name":  "SEL_GENERIC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x010a",
+        "ReturnType":  "void",
+        "Name":  "GET_DBG_NUM",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x010b",
+        "ReturnType":  "void",
+        "Name":  "NPC_QUEST_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x010c",
+        "ReturnType":  "void",
+        "Name":  "NPC_QUEST_END",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x010d",
+        "ReturnType":  "void",
+        "Name":  "NPC_QUEST_CLEAR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x010e",
+        "ReturnType":  "void",
+        "Name":  "COMENV_PLAY",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x010f",
+        "ReturnType":  "void",
+        "Name":  "COMENV_STOP",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0110",
+        "ReturnType":  "void",
+        "Name":  "VOICE1_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0111",
+        "ReturnType":  "void",
+        "Name":  "VOICE1_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0112",
+        "ReturnType":  "void",
+        "Name":  "VOICE2_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0113",
+        "ReturnType":  "void",
+        "Name":  "VOICE2_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0114",
+        "ReturnType":  "void",
+        "Name":  "VOICE3_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0115",
+        "ReturnType":  "void",
+        "Name":  "VOICE3_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0116",
+        "ReturnType":  "int",
+        "Name":  "TBL_365_VALUE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0117",
+        "ReturnType":  "int",
+        "Name":  "TBL_365_VALUE_MD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0118",
+        "ReturnType":  "void",
+        "Name":  "NEXT_TIME",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0119",
+        "ReturnType":  "void",
+        "Name":  "MDL_SET_LOOKAT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x011a",
+        "ReturnType":  "void",
+        "Name":  "MDL_RESET_LOOKAT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x011b",
+        "ReturnType":  "int",
+        "Name":  "CHK_PERSONA_EXIST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x011c",
+        "ReturnType":  "int",
+        "Name":  "GET_DAY_WEATHER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x011d",
+        "ReturnType":  "int",
+        "Name":  "GET_DAY_WEATHER_DETAIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x011e",
+        "ReturnType":  "int",
+        "Name":  "CHK_EXIST_WEATHER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x011f",
+        "ReturnType":  "int",
+        "Name":  "CHK_EXIST_WEATHER_DETAIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0120",
+        "ReturnType":  "void",
+        "Name":  "SEL_OPEN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0121",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM_NO_SE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0122",
+        "ReturnType":  "void",
+        "Name":  "TROPHY_REQUEST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0123",
+        "ReturnType":  "void",
+        "Name":  "PERSONA_EVOLUTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0124",
+        "ReturnType":  "int",
+        "Name":  "GET_PC_PARAM_DIFFERENCE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0125",
+        "ReturnType":  "int",
+        "Name":  "SEL_GENERIC_NOT_CANCEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0126",
+        "ReturnType":  "void",
+        "Name":  "FOOTSTEP_SE_PLAYER_CREATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0127",
+        "ReturnType":  "void",
+        "Name":  "FOOTSTEP_SE_ENABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0128",
+        "ReturnType":  "void",
+        "Name":  "FOOTSTEP_EFFECT_ENABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0129",
+        "ReturnType":  "void",
+        "Name":  "FOOTSTEP_EFFECT2_ENABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x012a",
+        "ReturnType":  "void",
+        "Name":  "FOOTSTEP_EFFECT_SCALE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x012b",
+        "ReturnType":  "void",
+        "Name":  "BGTEX_STRIP_ENABLE",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x012c",
+        "ReturnType":  "void",
+        "Name":  "BGENV_LINK_BGOBJ_INDEX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x012d",
+        "ReturnType":  "void",
+        "Name":  "RESET_PC_PARAM_UP",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x012e",
+        "ReturnType":  "void",
+        "Name":  "DISP_PC_PARAM_METER",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x012f",
+        "ReturnType":  "int",
+        "Name":  "GET_HERO_WANTED_EXP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0130",
+        "ReturnType":  "void",
+        "Name":  "DISP_PC_PARAM_RANK_UP",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0131",
+        "ReturnType":  "void",
+        "Name":  "SAVE_UI_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0132",
+        "ReturnType":  "int",
+        "Name":  "CHK_PC_PARAM_RANKUP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0133",
+        "ReturnType":  "void",
+        "Name":  "GET_ITEM_WINDOW",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0134",
+        "ReturnType":  "void",
+        "Name":  "GET_MONEY_WINDOW",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0135",
+        "ReturnType":  "void",
+        "Name":  "GET_PERSONA_WINDOW",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0136",
+        "ReturnType":  "void",
+        "Name":  "MSG_PERFORMANCE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0137",
+        "ReturnType":  "int",
+        "Name":  "CALL_STAMP_SAVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0138",
+        "ReturnType":  "int",
+        "Name":  "CALL_CLEAR_SAVE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0139",
+        "ReturnType":  "void",
+        "Name":  "BULLET_RECOVERY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x013a",
+        "ReturnType":  "void",
+        "Name":  "BGENV_AISAC_FADEOUT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x013b",
+        "ReturnType":  "void",
+        "Name":  "BGENV_AISAC_FADEIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x013c",
+        "ReturnType":  "void",
+        "Name":  "BGENV_AISAC_FADESYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x013d",
+        "ReturnType":  "void",
+        "Name":  "BGM_FADEIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x013e",
+        "ReturnType":  "void",
+        "Name":  "TEST_TEX_DISP2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x013f",
+        "ReturnType":  "void",
+        "Name":  "DAY_DISP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0140",
+        "ReturnType":  "void",
+        "Name":  "SND_VOICE_DNGEVT_SETUP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0141",
+        "ReturnType":  "void",
+        "Name":  "SND_VOICE_DNGEVT_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0142",
+        "ReturnType":  "void",
+        "Name":  "SND_VOICE_DNGEVT_FREE",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0143",
+        "ReturnType":  "void",
+        "Name":  "TEST_TEX_DISP3",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0144",
+        "ReturnType":  "void",
+        "Name":  "TEST_TEX_MOVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0145",
+        "ReturnType":  "void",
+        "Name":  "DISABLE_SHARE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0146",
+        "ReturnType":  "void",
+        "Name":  "ENABLE_SHARE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0147",
+        "ReturnType":  "void",
+        "Name":  "ALL_ENABLE_SHARE_PLAY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0148",
+        "ReturnType":  "void",
+        "Name":  "MDL_SET_LOOKAT_LIMIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0149",
+        "ReturnType":  "void",
+        "Name":  "SND_VOICE_BGMOB_DISABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x014a",
+        "ReturnType":  "void",
+        "Name":  "GOOD_GAUGE_DISP_ON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x014b",
+        "ReturnType":  "void",
+        "Name":  "GOOD_GAUGE_DISP_OFF",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x014c",
+        "ReturnType":  "void",
+        "Name":  "GET_ITEMS_WINDOW",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x014d",
+        "ReturnType":  "void",
+        "Name":  "GET_ITEM_BUF_SET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x014e",
+        "ReturnType":  "void",
+        "Name":  "GET_ITEM_BUF_RESET",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x014f",
+        "ReturnType":  "int",
+        "Name":  "CHK_PERSONA_IS_JAIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0150",
+        "ReturnType":  "void",
+        "Name":  "MDL_EMOTE_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0151",
+        "ReturnType":  "int",
+        "Name":  "SEL_GENERIC_EX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0152",
+        "ReturnType":  "int",
+        "Name":  "SEL_GENERIC_NOT_HELP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0153",
+        "ReturnType":  "void",
+        "Name":  "MDL_SET_LOOKAT_MOTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0154",
+        "ReturnType":  "void",
+        "Name":  "MDL_SET_LOOKAT_HORIZON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0155",
+        "ReturnType":  "int",
+        "Name":  "GET_CLOTH_TYPE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0156",
+        "ReturnType":  "int",
+        "Name":  "GET_YASUMI_SET_DAYS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0157",
+        "ReturnType":  "int",
+        "Name":  "GET_TOTALDAY_SET_DAYS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0158",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_SET_RESRC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0159",
+        "ReturnType":  "void",
+        "Name":  "MSG_TRIVIA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x015a",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM_LOOPSYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x015b",
+        "ReturnType":  "void",
+        "Name":  "CHAT_MSG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x015c",
+        "ReturnType":  "int",
+        "Name":  "CHAT_SEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x015d",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM_LINK_SE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x015e",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM_UNLINK_SE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x015f",
+        "ReturnType":  "void",
+        "Name":  "MDL_SET_LOOKAT_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0160",
+        "ReturnType":  "void",
+        "Name":  "LOADING_ICON_DISP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0161",
+        "ReturnType":  "void",
+        "Name":  "GOOD_GAUGE_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0162",
+        "ReturnType":  "void",
+        "Name":  "GOOD_GAUGE_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0163",
+        "ReturnType":  "int",
+        "Name":  "GET_SEASON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0164",
+        "ReturnType":  "void",
+        "Name":  "GOOD_GAUGE_START_EX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0165",
+        "ReturnType":  "void",
+        "Name":  "INIT_ITEM_SELECT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0166",
+        "ReturnType":  "void",
+        "Name":  "SET_ITEM_SELECT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0167",
+        "ReturnType":  "int",
+        "Name":  "START_ITEM_SELECT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0168",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_QUAKE_2_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0169",
+        "ReturnType":  "void",
+        "Name":  "CAMERA_QUAKE_2_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x016a",
+        "ReturnType":  "void",
+        "Name":  "MDL_ICON_END",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x016b",
+        "ReturnType":  "int",
+        "Name":  "MDL_ICON_EX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x016c",
+        "ReturnType":  "void",
+        "Name":  "MDL_ICON_SET_SCALE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x016d",
+        "ReturnType":  "void",
+        "Name":  "CLEAR_INHERIT_DATA",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x016e",
+        "ReturnType":  "void",
+        "Name":  "GOOD_GAUGE_LOAD_EX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x016f",
+        "ReturnType":  "void",
+        "Name":  "GOOD_GAUGE_SYNC_EX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0170",
+        "ReturnType":  "void",
+        "Name":  "GOOD_GAUGE_END_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0171",
+        "ReturnType":  "void",
+        "Name":  "MDL_TRACK_CLEAR_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0172",
+        "ReturnType":  "void",
+        "Name":  "START_PLAY_GO_CHECK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0173",
+        "ReturnType":  "int",
+        "Name":  "SYNC_PLAY_GO_CHECK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0174",
+        "ReturnType":  "void",
+        "Name":  "NET_DISCONNECT_MATCH",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0175",
+        "ReturnType":  "void",
+        "Name":  "SEL_SELNO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0176",
+        "ReturnType":  "void",
+        "Name":  "SEL_GENERIC_MASK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0177",
+        "ReturnType":  "void",
+        "Name":  "SEL_GENERIC_DISABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0178",
+        "ReturnType":  "int",
+        "Name":  "CHK_EX_SEASON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0179",
+        "ReturnType":  "void",
+        "Name":  "PERSONA_EVOLUTION_02",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x017a",
+        "ReturnType":  "int",
+        "Name":  "GET_PLAYER_LV",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x017b",
+        "ReturnType":  "int",
+        "Name":  "GET_EQUIP_PERSONA_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x017c",
+        "ReturnType":  "void",
+        "Name":  "MSG_DEVIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x017d",
+        "ReturnType":  "int",
+        "Name":  "CHK_CMB_SPECIAL_TIME",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x017e",
+        "ReturnType":  "void",
+        "Name":  "FAKE_DATE_SET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x017f",
+        "ReturnType":  "void",
+        "Name":  "FAKE_DATE_RESET",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0180",
+        "ReturnType":  "void",
+        "Name":  "SND_VOICE_DLYEVT_SETUP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0181",
+        "ReturnType":  "void",
+        "Name":  "SND_VOICE_DLYEVT_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0182",
+        "ReturnType":  "void",
+        "Name":  "SND_VOICE_DLYEVT_FREE",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0183",
+        "ReturnType":  "int",
+        "Name":  "GET_ITEM_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0184",
+        "ReturnType":  "int",
+        "Name":  "GET_EQUIP_ENABLE_PLAYER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0185",
+        "ReturnType":  "int",
+        "Name":  "GET_ITEM_ATTACK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0186",
+        "ReturnType":  "int",
+        "Name":  "CHANGE_EQUIP_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0187",
+        "ReturnType":  "void",
+        "Name":  "DAY_DISP_CHANGE_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0188",
+        "ReturnType":  "int",
+        "Name":  "CHK_PERSONA_EVOLUTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0189",
+        "ReturnType":  "void",
+        "Name":  "VOICE1_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x018a",
+        "ReturnType":  "void",
+        "Name":  "VOICE2_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x018b",
+        "ReturnType":  "void",
+        "Name":  "VOICE3_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x018c",
+        "ReturnType":  "void",
+        "Name":  "SET_EQUIP_PERSONA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x018d",
+        "ReturnType":  "void",
+        "Name":  "AWARD_REQUEST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x018e",
+        "ReturnType":  "int",
+        "Name":  "GET_OPERATION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x018f",
+        "ReturnType":  "void",
+        "Name":  "SET_OPERATION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0190",
+        "ReturnType":  "int",
+        "Name":  "CHECK_EXIST_BEFORE_SAVEDATA",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0191",
+        "ReturnType":  "void",
+        "Name":  "PURGE_RESRC_CACHE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0192",
+        "ReturnType":  "int",
+        "Name":  "SEL_HERO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0193",
+        "ReturnType":  "void",
+        "Name":  "SEL_HERO_MASK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0194",
+        "ReturnType":  "void",
+        "Name":  "SEL_HERO_NOTSEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0195",
+        "ReturnType":  "int",
+        "Name":  "GET_PC_PARAM_EXP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0196",
+        "ReturnType":  "int",
+        "Name":  "GET_LOCAL_TIME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0197",
+        "ReturnType":  "int",
+        "Name":  "GET_AWARD_UNLOCK_COUNT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0198",
+        "ReturnType":  "int",
+        "Name":  "CHECK_AWARD_UNLOCK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x0199",
+        "ReturnType":  "int",
+        "Name":  "CHECK_MYP_CONTENTS_COMPLETE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x019a",
+        "ReturnType":  "int",
+        "Name":  "GET_SYS_SCRIPT_FLAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x019b",
+        "ReturnType":  "void",
+        "Name":  "SET_SYS_SCRIPT_FLAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x019c",
+        "ReturnType":  "void",
+        "Name":  "CHAT_WND_CLS_WAIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x019d",
+        "ReturnType":  "int",
+        "Name":  "CHECK_DISABLE_SHARE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x019e",
+        "ReturnType":  "int",
+        "Name":  "GET_PC_LEVEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x019f",
+        "ReturnType":  "void",
+        "Name":  "START_PC_LEVEL_UP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x01a0",
+        "ReturnType":  "int",
+        "Name":  "FRIEND_GET_SP_SKILL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x01a1",
+        "ReturnType":  "void",
+        "Name":  "FLAG_DATA_INPUT",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x01a2",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM_LINK_STOP_SE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x01a3",
+        "ReturnType":  "void",
+        "Name":  "FLAG_DATA_INPUT_SYNC",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x01a4",
+        "ReturnType":  "void",
+        "Name":  "E_LIGHT_RESET",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    }
+]

--- a/Source/AtlusScriptLibrary/Libraries/Persona5Royal/Modules/Facility/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona5Royal/Modules/Facility/Functions.json
@@ -1,0 +1,2243 @@
+[
+    {
+        "Index":  "0x4000",
+        "ReturnType":  "void",
+        "Name":  "CALL_WEAPON_SHOP",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4001",
+        "ReturnType":  "void",
+        "Name":  "CALL_ITEM_SHOP",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4002",
+        "ReturnType":  "void",
+        "Name":  "CALL_COMBINE_SHOP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4003",
+        "ReturnType":  "void",
+        "Name":  "CALL_QUEST_DAYTIME",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4004",
+        "ReturnType":  "void",
+        "Name":  "SET_QUEST_BEFORE_DUNGEON",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4005",
+        "ReturnType":  "void",
+        "Name":  "RESET_QUEST_AFTER_DUNGEON",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4006",
+        "ReturnType":  "void",
+        "Name":  "CHECK_CONSET_QUEST",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4007",
+        "ReturnType":  "void",
+        "Name":  "START_QUEST_CLEAR_EFFECT",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4008",
+        "ReturnType":  "void",
+        "Name":  "CHECK_QUEST_CLEAR_ENEMY",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4009",
+        "ReturnType":  "void",
+        "Name":  "CHECK_QUEST_CLEAR_BOSS",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x400a",
+        "ReturnType":  "void",
+        "Name":  "CHECK_QUEST_CLEAR_ITEM",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x400b",
+        "ReturnType":  "int",
+        "Name":  "GET_COMB_MATPER_MAJOR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x400c",
+        "ReturnType":  "int",
+        "Name":  "GET_COMB_MATPER_MINOR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x400d",
+        "ReturnType":  "int",
+        "Name":  "GET_COMB_RETPER_MAJOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x400e",
+        "ReturnType":  "int",
+        "Name":  "GET_COMB_RETPER_MINOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x400f",
+        "ReturnType":  "void",
+        "Name":  "CALL_NAME_ENTRY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4010",
+        "ReturnType":  "void",
+        "Name":  "FCL_SHOP_CHANGE_FLAG",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4011",
+        "ReturnType":  "void",
+        "Name":  "UI_MISSION_OFFER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4012",
+        "ReturnType":  "void",
+        "Name":  "UI_MISSION_END",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4013",
+        "ReturnType":  "int",
+        "Name":  "UI_MISSION_CHECK_OFFER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4014",
+        "ReturnType":  "int",
+        "Name":  "UI_MISSION_CHECK_END",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4015",
+        "ReturnType":  "void",
+        "Name":  "MISSION_START_EFFECT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4016",
+        "ReturnType":  "void",
+        "Name":  "MISSION_COMPLETE_EFFECT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4017",
+        "ReturnType":  "void",
+        "Name":  "CALL_ROUTE_MAP",
+        "Description":  "Null function pointer",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4018",
+        "ReturnType":  "void",
+        "Name":  "CALL_ITEM_SHOP_EX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4019",
+        "ReturnType":  "void",
+        "Name":  "CALL_WEAPON_SHOP_EX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x401a",
+        "ReturnType":  "int",
+        "Name":  "MISSION_GET_STATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x401b",
+        "ReturnType":  "void",
+        "Name":  "MISSION_SET_STATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x401c",
+        "ReturnType":  "void",
+        "Name":  "MISSION_UPDATE_EVERY_DAY",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x401d",
+        "ReturnType":  "int",
+        "Name":  "CALL_PUBLIC_SHOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x401e",
+        "ReturnType":  "void",
+        "Name":  "CALL_DIARY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x401f",
+        "ReturnType":  "int",
+        "Name":  "CHECK_PUBLIC_SHOP_STOCK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4020",
+        "ReturnType":  "void",
+        "Name":  "CALL_CHAT_CHECK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4021",
+        "ReturnType":  "void",
+        "Name":  "CALL_CHAT_LIST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4022",
+        "ReturnType":  "void",
+        "Name":  "CALL_QUEST_ORDER",
+        "Description":  "Null function pointer",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4023",
+        "ReturnType":  "void",
+        "Name":  "CALL_CHAT_DIRECT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4024",
+        "ReturnType":  "void",
+        "Name":  "CALL_WEAPON_SHOP_DATA_LOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4025",
+        "ReturnType":  "void",
+        "Name":  "CALL_WEAPON_SHOP_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4026",
+        "ReturnType":  "void",
+        "Name":  "CALL_TUTORIAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4027",
+        "ReturnType":  "void",
+        "Name":  "CALL_GLOBAL_MONEY_PANEL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4028",
+        "ReturnType":  "void",
+        "Name":  "DEL_GLOBAL_MONEY_PANEL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4029",
+        "ReturnType":  "void",
+        "Name":  "CALL_WANTED_EXP_PANEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x402a",
+        "ReturnType":  "void",
+        "Name":  "CALL_WANTED_EXP_NO_WAIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x402b",
+        "ReturnType":  "void",
+        "Name":  "ADD_REPUTATION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x402c",
+        "ReturnType":  "void",
+        "Name":  "ADD_REPUTATION_NO_WAIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x402d",
+        "ReturnType":  "void",
+        "Name":  "ADD_REPUTATION_FORCE_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x402e",
+        "ReturnType":  "void",
+        "Name":  "SET_REPUTATION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x402f",
+        "ReturnType":  "int",
+        "Name":  "GET_REPUTATION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4030",
+        "ReturnType":  "void",
+        "Name":  "CALL_ITEM_SHOP_DATA_LOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4031",
+        "ReturnType":  "int",
+        "Name":  "CALL_ARBEIT_BOOK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4032",
+        "ReturnType":  "void",
+        "Name":  "DIRECT_SUBSCRIBE_ARBEIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4033",
+        "ReturnType":  "int",
+        "Name":  "CHECK_SUBSCRIBE_ARBEIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4034",
+        "ReturnType":  "int",
+        "Name":  "CHECK_ENABLE_ARBEIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4035",
+        "ReturnType":  "void",
+        "Name":  "CALL_WANTED_EXP_BATTLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4036",
+        "ReturnType":  "void",
+        "Name":  "RESET_INJECTION_EFFECT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4037",
+        "ReturnType":  "int",
+        "Name":  "SKILLCARD_COPY_CHK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4038",
+        "ReturnType":  "int",
+        "Name":  "SKILLCARD_LIST_DISP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4039",
+        "ReturnType":  "void",
+        "Name":  "CALL_PHANTOM_NAME_ENTRY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x403a",
+        "ReturnType":  "void",
+        "Name":  "EXEC_EVT_COMBINE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x403b",
+        "ReturnType":  "int",
+        "Name":  "GET_PUBLIC_SHOP_BUY_TYPE_NUM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x403c",
+        "ReturnType":  "int",
+        "Name":  "GET_PUBLIC_SHOP_ITEM_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x403d",
+        "ReturnType":  "int",
+        "Name":  "GET_PUBLIC_SHOP_ITEM_BUY_NUM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x403e",
+        "ReturnType":  "int",
+        "Name":  "CHECK_PUBLIC_SHOP_SET_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x403f",
+        "ReturnType":  "int",
+        "Name":  "GET_PUBLIC_SHOP_SET_ITEM_PACK_NUM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4040",
+        "ReturnType":  "int",
+        "Name":  "GET_PUBLIC_SHOP_SET_ITEM_PACK_ITEM_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4041",
+        "ReturnType":  "void",
+        "Name":  "PUBLIC_SHOP_BUY_ITEM_COPY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4042",
+        "ReturnType":  "void",
+        "Name":  "PUBLIC_SHOP_BUY_ITEM_BAG_IN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4043",
+        "ReturnType":  "void",
+        "Name":  "CALL_CHAT_READ_UN_READ",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4044",
+        "ReturnType":  "void",
+        "Name":  "CALL_CONF_COOPERATION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4045",
+        "ReturnType":  "void",
+        "Name":  "CHAT_RESERVE_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4046",
+        "ReturnType":  "void",
+        "Name":  "CALL_CHAT_ARRIVAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4047",
+        "ReturnType":  "void",
+        "Name":  "CHAT_ALL_CLEAR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4048",
+        "ReturnType":  "int",
+        "Name":  "CHAT_GET_ARRIVAL_MONTH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4049",
+        "ReturnType":  "int",
+        "Name":  "CHAT_GET_ARRIVAL_DAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x404a",
+        "ReturnType":  "void",
+        "Name":  "CMB_CELL_ERASE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x404b",
+        "ReturnType":  "void",
+        "Name":  "CHAT_SET_SWITCH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x404c",
+        "ReturnType":  "int",
+        "Name":  "CHAT_CHECK_SWITCH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x404d",
+        "ReturnType":  "void",
+        "Name":  "CMB_PREPARE_START",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x404e",
+        "ReturnType":  "void",
+        "Name":  "CMB_PREPARE_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x404f",
+        "ReturnType":  "int",
+        "Name":  "CHAT_GET_UNREAD_NUM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4050",
+        "ReturnType":  "void",
+        "Name":  "OPEN_FAILED_QUEST_LIST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4051",
+        "ReturnType":  "int",
+        "Name":  "SYNC_FAILED_QUEST_LIST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4052",
+        "ReturnType":  "void",
+        "Name":  "RESTART_FAILED_QUEST_LIST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4053",
+        "ReturnType":  "void",
+        "Name":  "CLOSE_FAILED_QUEST_LIST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4054",
+        "ReturnType":  "void",
+        "Name":  "CALL_WANTED_EXP_LEVELUP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4055",
+        "ReturnType":  "int",
+        "Name":  "MISSION_GET_NUM_STATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4056",
+        "ReturnType":  "int",
+        "Name":  "CHANGE_GLOBAL_MONEY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4057",
+        "ReturnType":  "int",
+        "Name":  "MISSION_GET_RANK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4058",
+        "ReturnType":  "void",
+        "Name":  "ADD_PUBLIC_SHOP_CHOICE_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4059",
+        "ReturnType":  "void",
+        "Name":  "SET_PUBLIC_SHOP_CHOICE_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x405a",
+        "ReturnType":  "void",
+        "Name":  "CALL_GLOBAL_MONEY_PANEL_EX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x405b",
+        "ReturnType":  "void",
+        "Name":  "CHAT_SET_HOLD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x405c",
+        "ReturnType":  "int",
+        "Name":  "CHAT_CHECK_HOLD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x405d",
+        "ReturnType":  "void",
+        "Name":  "CALL_GLOBAL_ITEM_PANEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x405e",
+        "ReturnType":  "void",
+        "Name":  "DEL_GLOBAL_ITEM_PANEL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x405f",
+        "ReturnType":  "int",
+        "Name":  "CHANGE_GLOBAL_ITEM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4060",
+        "ReturnType":  "int",
+        "Name":  "CHANGE_GLOBAL_ITEM_EX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4061",
+        "ReturnType":  "int",
+        "Name":  "IMG_CREATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4062",
+        "ReturnType":  "void",
+        "Name":  "IMG_DELETE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4063",
+        "ReturnType":  "void",
+        "Name":  "IMG_LOAD_CALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4064",
+        "ReturnType":  "void",
+        "Name":  "IMG_LOAD_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4065",
+        "ReturnType":  "void",
+        "Name":  "IMG_ANIM_CALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4066",
+        "ReturnType":  "void",
+        "Name":  "IMG_ANIM_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4067",
+        "ReturnType":  "int",
+        "Name":  "CHAT_GET_JOIN_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4068",
+        "ReturnType":  "void",
+        "Name":  "IMG_DSP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4069",
+        "ReturnType":  "void",
+        "Name":  "IMG_CLS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x406a",
+        "ReturnType":  "int",
+        "Name":  "CHANGE_GLOBAL_MONEY_EX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x406b",
+        "ReturnType":  "void",
+        "Name":  "OPEN_QUEST_LIST_DISP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x406c",
+        "ReturnType":  "int",
+        "Name":  "CMB_GET_PBOOK_REGIST_RATE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x406d",
+        "ReturnType":  "int",
+        "Name":  "CALL_FICTION_DRAW",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x406e",
+        "ReturnType":  "void",
+        "Name":  "SET_PUBLIC_SHOP_CHOICE_ITEM_DISCOUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x406f",
+        "ReturnType":  "void",
+        "Name":  "CHAT_RESET_DIRECT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4070",
+        "ReturnType":  "void",
+        "Name":  "CALL_DIFFICULT_SET",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4071",
+        "ReturnType":  "void",
+        "Name":  "UPDATE_CMB_EVERYMORNING",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4072",
+        "ReturnType":  "void",
+        "Name":  "CALL_DARTS_TASK_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4073",
+        "ReturnType":  "int",
+        "Name":  "CALL_DARTS_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4074",
+        "ReturnType":  "void",
+        "Name":  "DARTS_LOOP_COUNT_ADD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4075",
+        "ReturnType":  "int",
+        "Name":  "DARTS_LOOP_COUNT_CHK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4076",
+        "ReturnType":  "void",
+        "Name":  "CALL_DARTS_TASK_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4077",
+        "ReturnType":  "int",
+        "Name":  "CALL_PUBLIC_SHOP_TV",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4078",
+        "ReturnType":  "void",
+        "Name":  "CALL_STAMP_SHOP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4079",
+        "ReturnType":  "int",
+        "Name":  "CALL_MEMENTOS_SHOP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x407a",
+        "ReturnType":  "void",
+        "Name":  "CALL_EXROOT_END_DRAW",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x407b",
+        "ReturnType":  "void",
+        "Name":  "SET_COMBINE_SPECIAL_MODE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x407c",
+        "ReturnType":  "int",
+        "Name":  "CALL_BILLIARDS_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x407d",
+        "ReturnType":  "void",
+        "Name":  "DARTS_SET_NPC_SCORE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x407e",
+        "ReturnType":  "void",
+        "Name":  "CALL_DARTS_TASK_START_EX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x407f",
+        "ReturnType":  "int",
+        "Name":  "CALL_DARTS_PLAY_EX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4080",
+        "ReturnType":  "int",
+        "Name":  "CALL_VINTAGE_SHOP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4081",
+        "ReturnType":  "void",
+        "Name":  "CALL_DARTS_TASK_START_ROUND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4082",
+        "ReturnType":  "int",
+        "Name":  "CALL_DARTS_PLAY_ROUND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4083",
+        "ReturnType":  "int",
+        "Name":  "GET_VINTAGE_SHOP_SELL_NUM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4084",
+        "ReturnType":  "int",
+        "Name":  "CHK_DARTS_BUST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4085",
+        "ReturnType":  "void",
+        "Name":  "CALL_PERSONA_SKILL_CARD_SHOP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4086",
+        "ReturnType":  "void",
+        "Name":  "CALL_DARTS_WIPE_FADE_IN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4087",
+        "ReturnType":  "void",
+        "Name":  "CALL_DARTS_WIPE_START",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4088",
+        "ReturnType":  "void",
+        "Name":  "DARTS_WIPE_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4089",
+        "ReturnType":  "void",
+        "Name":  "CALL_DARTS_WIPE_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x408a",
+        "ReturnType":  "int",
+        "Name":  "DARTS_WIPE_TIMER_CHECK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x408b",
+        "ReturnType":  "void",
+        "Name":  "DARTS_WIPE_START_FADE_IN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x408c",
+        "ReturnType":  "int",
+        "Name":  "CALL_DARTS_MEMB_LIST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x408d",
+        "ReturnType":  "void",
+        "Name":  "SKILLCARD_COPY_CONFIRM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x408e",
+        "ReturnType":  "int",
+        "Name":  "SKILLCARD_LIST_DISP_CREATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x408f",
+        "ReturnType":  "int",
+        "Name":  "SKILLCARD_LIST_DISP_CREATE_ALL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4090",
+        "ReturnType":  "int",
+        "Name":  "SKILLCARD_CREATE_CHK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4091",
+        "ReturnType":  "int",
+        "Name":  "SKILLCARD_CREATE_CHK_ALL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4092",
+        "ReturnType":  "void",
+        "Name":  "CALL_DARTS_TASK_START_RESRC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4093",
+        "ReturnType":  "int",
+        "Name":  "CALL_CHALLENGE_BTL_SEL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4094",
+        "ReturnType":  "void",
+        "Name":  "CONFIRM_PS_STATUS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4095",
+        "ReturnType":  "int",
+        "Name":  "SELECT_FRIEND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4096",
+        "ReturnType":  "int",
+        "Name":  "CHECK_HAVE_INCENSE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4097",
+        "ReturnType":  "void",
+        "Name":  "START_VIDEO_VIEWER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4098",
+        "ReturnType":  "void",
+        "Name":  "START_SOUND_VIEWER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x4099",
+        "ReturnType":  "void",
+        "Name":  "START_IMAGE_VIEWER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x409a",
+        "ReturnType":  "void",
+        "Name":  "COMFIRM_PS_PARAM_UP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param7",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x409b",
+        "ReturnType":  "int",
+        "Name":  "CALL_DARTS_MEMB_LIST_CONF",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x409c",
+        "ReturnType":  "void",
+        "Name":  "START_PALACE_MAKER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x409d",
+        "ReturnType":  "void",
+        "Name":  "CALL_TEC_RANK_START",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x409e",
+        "ReturnType":  "void",
+        "Name":  "CALL_TEC_RANK_START_EX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x409f",
+        "ReturnType":  "void",
+        "Name":  "CALL_BILLIARDS_RESULT_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40a0",
+        "ReturnType":  "void",
+        "Name":  "START_DARTS_BATONTOUCH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40a1",
+        "ReturnType":  "void",
+        "Name":  "START_AWARD_VIEWER2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40a2",
+        "ReturnType":  "void",
+        "Name":  "MYP_CONF_OBJECT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40a3",
+        "ReturnType":  "void",
+        "Name":  "DARTS_CMD_INITIALIZE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40a4",
+        "ReturnType":  "int",
+        "Name":  "DARTS_CMD_GET_PCID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40a5",
+        "ReturnType":  "void",
+        "Name":  "DARTS_CMD_RELEASE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40a6",
+        "ReturnType":  "int",
+        "Name":  "DARTS_CMD_GET_POSITION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40a7",
+        "ReturnType":  "void",
+        "Name":  "CALL_DARTS_TASK_START_RESRC_EX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40a8",
+        "ReturnType":  "int",
+        "Name":  "DARTS_CMD_CHK_NPC_FINISH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40a9",
+        "ReturnType":  "void",
+        "Name":  "DARTS_CMD_SET_FINISH_MODE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40aa",
+        "ReturnType":  "int",
+        "Name":  "DARTS_CMD_GET_CHALLENGE_POINT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40ab",
+        "ReturnType":  "int",
+        "Name":  "DARTS_CMD_COMPARISON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40ac",
+        "ReturnType":  "int",
+        "Name":  "DARTS_CMD_GET_CHALLENGE_HIGH_RANK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40ad",
+        "ReturnType":  "int",
+        "Name":  "CALL_PUBLIC_SHOP_FREE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x40ae",
+        "ReturnType":  "void",
+        "Name":  "FCL_SET_CUSTOM_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    }
+]

--- a/Source/AtlusScriptLibrary/Libraries/Persona5Royal/Modules/Field/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona5Royal/Modules/Field/Functions.json
@@ -1,0 +1,14225 @@
+[
+    {
+        "Index":  "0x1000",
+        "ReturnType":  "void",
+        "Name":  "CALL_FIELD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1001",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_SCRIPT_TIMING",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1002",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_CHANGE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1003",
+        "ReturnType":  "int",
+        "Name":  "FLD_PC_GET_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1004",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_GET_RESHND",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1005",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_LOCK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1006",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_UNLOCK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1007",
+        "ReturnType":  "int",
+        "Name":  "FLD_OBJ_GET_RESHND",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1008",
+        "ReturnType":  "int",
+        "Name":  "FLD_OPEN_DOOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1009",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_TBOX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x100a",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_TBOX_FLAG",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x100b",
+        "ReturnType":  "void",
+        "Name":  "FLD_SWITCH_FAILURE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x100c",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_SET_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x100d",
+        "ReturnType":  "int",
+        "Name":  "FLD_OPEN_DOOR_NO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x100e",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_SUBJECT_MODE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x100f",
+        "ReturnType":  "void",
+        "Name":  "FLD_SOBJ_RECOVER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1010",
+        "ReturnType":  "void",
+        "Name":  "FLD_NEXT_DNG_LEVEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1011",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_DNG_LEVEL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1012",
+        "ReturnType":  "void",
+        "Name":  "FLD_MAP_SEARCH",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1013",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_DNG_AREA_DIR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1014",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_SET_DNG_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1015",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROT_CAMERA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1016",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROT_WORLD_CAMERA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1017",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROT_DOOR_CAMERA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1018",
+        "ReturnType":  "void",
+        "Name":  "FLD_REPORT_MSG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1019",
+        "ReturnType":  "void",
+        "Name":  "FLD_REPORT_MSGSYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x101a",
+        "ReturnType":  "void",
+        "Name":  "FLD_REPORT_FREE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x101b",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_TARGET_ENEMY_TYPE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x101c",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_ENCOUNTID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x101d",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_MAJOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x101e",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_MINOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x101f",
+        "ReturnType":  "void",
+        "Name":  "FLD_RETRY_SAVE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1020",
+        "ReturnType":  "void",
+        "Name":  "FLD_RETRY_LOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1021",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_SET_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1022",
+        "ReturnType":  "int",
+        "Name":  "FLD_MODEL_LOADSYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1023",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_MODEL_LOAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1024",
+        "ReturnType":  "int",
+        "Name":  "FLD_OBJ_MODEL_LOAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1025",
+        "ReturnType":  "int",
+        "Name":  "FLD_OBJ_MODEL_LOADSYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1026",
+        "ReturnType":  "void",
+        "Name":  "FLD_OBJ_MODEL_COLLIS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1027",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1028",
+        "ReturnType":  "void",
+        "Name":  "CALL_BKUP_FIELD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1029",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_SAVE_COUNTER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x102a",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_DNG_NO",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x102b",
+        "ReturnType":  "void",
+        "Name":  "FLD_DUNGEON_EFFECT_ENABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x102c",
+        "ReturnType":  "void",
+        "Name":  "FLD_CINEMASCOPE_VISIBLE",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x102d",
+        "ReturnType":  "void",
+        "Name":  "FLD_REQ_FLASHBACK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x102e",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_DNG_EDIT_FLOOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x102f",
+        "ReturnType":  "int",
+        "Name":  "FLD_OBJ_CNV_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1030",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_SET_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1031",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_ADD_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1032",
+        "ReturnType":  "void",
+        "Name":  "FLD_OPEN_ORD_DOOR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1033",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_ENEMY_NUM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1034",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_TBOX_TYPE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1035",
+        "ReturnType":  "void",
+        "Name":  "FLD_SETUP_MOVIE_TEX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1036",
+        "ReturnType":  "void",
+        "Name":  "FLD_PLAY_MOVIE_TEX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1037",
+        "ReturnType":  "void",
+        "Name":  "FLD_PAUSE_MOVIE_TEX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1038",
+        "ReturnType":  "void",
+        "Name":  "FLD_SYNC_MOVIE_TEX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1039",
+        "ReturnType":  "void",
+        "Name":  "FLD_OPEN_TBOX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x103a",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_SET_HELPERID_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x103b",
+        "ReturnType":  "int",
+        "Name":  "FLD_ENEMY_MODEL_LOAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x103c",
+        "ReturnType":  "int",
+        "Name":  "FLD_SYMBOL_MODEL_LOAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x103d",
+        "ReturnType":  "void",
+        "Name":  "FLD_END_FLASHBACK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x103e",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_ENCOUNT_ENEMY_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x103f",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_ENCOUNT_ENEMY_NUM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1040",
+        "ReturnType":  "void",
+        "Name":  "CALL_TITLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1041",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_X_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1042",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_Y_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1043",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_Z_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1044",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_SYNC_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1045",
+        "ReturnType":  "int",
+        "Name":  "FLD_CAMERA_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1046",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_READ_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x002c CAMERA_READ_SYNC"
+    },
+    {
+        "Index":  "0x1047",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_FREE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1048",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_SET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x002e CAMERA_SET"
+    },
+    {
+        "Index":  "0x1049",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_RESET",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  "Alias of 0x002f CAMERA_RESET"
+    },
+    {
+        "Index":  "0x104a",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x0030 CAMERA_ANIM"
+    },
+    {
+        "Index":  "0x104b",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_ANIM_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x0031 CAMERA_ANIM_SYNC"
+    },
+    {
+        "Index":  "0x104c",
+        "ReturnType":  "int",
+        "Name":  "FLD_SCRIPT_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x104d",
+        "ReturnType":  "void",
+        "Name":  "FLD_SCRIPT_READ_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x004c SCRIPT_READ_SYNC"
+    },
+    {
+        "Index":  "0x104e",
+        "ReturnType":  "void",
+        "Name":  "FLD_SCRIPT_FREE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x104f",
+        "ReturnType":  "void",
+        "Name":  "FLD_SCRIPT_EXEC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1050",
+        "ReturnType":  "int",
+        "Name":  "FLD_SCRIPT_SEARCH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1051",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_SET_HELPERPOS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x0050 CAMERA_SET_HELPERPOS"
+    },
+    {
+        "Index":  "0x1052",
+        "ReturnType":  "void",
+        "Name":  "FLD_UNIT_SET_EVT_WAIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1053",
+        "ReturnType":  "int",
+        "Name":  "FLD_SEARCH_DNG_NEAR_QUEST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1054",
+        "ReturnType":  "void",
+        "Name":  "FLD_GET_SCH_OBJ_BEGIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1055",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DOF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1056",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DOF_DEFAULT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1057",
+        "ReturnType":  "void",
+        "Name":  "FLD_GMC_LIGHT_ADD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1058",
+        "ReturnType":  "void",
+        "Name":  "FLD_GMC_LIGHT_UPDATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1059",
+        "ReturnType":  "int",
+        "Name":  "FLD_GMC_LIGHT_GET_UID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x105a",
+        "ReturnType":  "int",
+        "Name":  "FLD_GMC_LIGHT_CTRL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x105b",
+        "ReturnType":  "void",
+        "Name":  "FLD_GMC_LIGHT_FAR_CAMERA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param7",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param8",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x105c",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_HDR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x105d",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_HDR_STAR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x105e",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_HDR_DEFAULT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x105f",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_HDR_STAR_DEFAULT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1060",
+        "ReturnType":  "void",
+        "Name":  "FLD_SWITCH_SET_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1061",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_REST_COUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1062",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_USE_REST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1063",
+        "ReturnType":  "void",
+        "Name":  "FLD_USE_REST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1064",
+        "ReturnType":  "void",
+        "Name":  "FLD_GET_SEED",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1065",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_CAMERA_COLLIS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1066",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_REST_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1067",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_REST_ITEM_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1068",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROT_OBJ_CAMERA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1069",
+        "ReturnType":  "void",
+        "Name":  "FLD_PROHIBIT_ENEMY_PATH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x106a",
+        "ReturnType":  "void",
+        "Name":  "FLD_START_SUPPORT_MSG",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x106b",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_DUNGEON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x106c",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_AT_DUNGEON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x106d",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x106e",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_INTERP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x106f",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_SYNC_INTERP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1070",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_ATTACH_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1071",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_DETACH_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1072",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_ATTACH_ITEM_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1073",
+        "ReturnType":  "void",
+        "Name":  "FLD_TEX_TEST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1074",
+        "ReturnType":  "void",
+        "Name":  "FLD_TEX_TEST_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1075",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_SET_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1076",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_SET_ROT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1077",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_OPEN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1078",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_CLOSE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1079",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_SET_LAYER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x107a",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_MASK_ON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x107b",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_MASK_OFF",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x107c",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_MASK_SETCLIP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x107d",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_LOCK_INTERP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param7",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param8",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x107e",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_LOCK_SYNC_INTERP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x107f",
+        "ReturnType":  "int",
+        "Name":  "FLD_EFFECT_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1080",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_ALERT_VALUE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1081",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_ALERT_VALUE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1082",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_SET_FIXED_COLLIS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1083",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_MODEL_READPAUSE_CANCEL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1084",
+        "ReturnType":  "void",
+        "Name":  "FLD_CROWD_MODEL_READPAUSE_CANCEL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1085",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_ENEMY_ENCOUNT_NO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1086",
+        "ReturnType":  "void",
+        "Name":  "FLD_PROHIBIT_ENEMY_AREA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1087",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_SUMMON_LIFE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1088",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1089",
+        "ReturnType":  "void",
+        "Name":  "FLD_REQ_BGM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x108a",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_ENEMY_IGNORE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x108b",
+        "ReturnType":  "void",
+        "Name":  "FLD_START_SMK_BALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x108c",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_ATDNG_SHOP_EFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x108d",
+        "ReturnType":  "int",
+        "Name":  "FLD_REQ_ATDNG_SHOP_ENTER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x108e",
+        "ReturnType":  "int",
+        "Name":  "FLD_SUMMON_ENEMY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x108f",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_SET_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1090",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_ADD_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1091",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_PATH_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1092",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_SYNC_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1093",
+        "ReturnType":  "int",
+        "Name":  "FLD_LOAD_PATH_DATA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1094",
+        "ReturnType":  "void",
+        "Name":  "FLD_SYNC_PATH_DATA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1095",
+        "ReturnType":  "void",
+        "Name":  "FLD_FREE_PATH_DATA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1096",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_DEBUG_FLAG",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1097",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_SEARCH_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1098",
+        "ReturnType":  "void",
+        "Name":  "FLD_WIRE_OBJ_ENABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1099",
+        "ReturnType":  "void",
+        "Name":  "FLD_GET_SCH_OBJ_COIN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x109a",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_CELLPHONE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x109b",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_DISP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x109c",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_BANK_LOAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x109d",
+        "ReturnType":  "int",
+        "Name":  "FLD_EFFECT_BANK_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x109e",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_BANK_FREE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x109f",
+        "ReturnType":  "int",
+        "Name":  "FLD_EFFECT_BANK_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10a0",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_END",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10a1",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_FADE_OUT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10a2",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_SET_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10a3",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_SET_RES_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10a4",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_SET_ROT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10a5",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_SET_RES_ROT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10a6",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_SET_SCALE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10a7",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_SET_ALPHA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10a8",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_SET_SPEED",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10a9",
+        "ReturnType":  "void",
+        "Name":  "FLD_SEARCH_EFFECT_ON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10aa",
+        "ReturnType":  "void",
+        "Name":  "FLD_SEARCH_EFFECT_OFF",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ab",
+        "ReturnType":  "int",
+        "Name":  "FLD_SEARCH_EFFECT_CHECK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ac",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_HIDE_DISABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ad",
+        "ReturnType":  "void",
+        "Name":  "FLD_CLEAR_SUMMON_ENEMY_ALL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ae",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_RELATE_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10af",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_X_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10b0",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_Y_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10b1",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_Z_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10b2",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_ORIENT_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10b3",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_POS_INDEX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10b4",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_LOOKAT_INTERP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10b5",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_FOVY_INTERP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10b6",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_SET_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10b7",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_SYNC_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10b8",
+        "ReturnType":  "void",
+        "Name":  "FLD_PTY_MODEL_SET_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10b9",
+        "ReturnType":  "void",
+        "Name":  "FLD_PTY_MODEL_SYNC_VISIBLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ba",
+        "ReturnType":  "void",
+        "Name":  "FLD_EMY_MODEL_SET_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10bb",
+        "ReturnType":  "void",
+        "Name":  "FLD_EMY_MODEL_SYNC_VISIBLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10bc",
+        "ReturnType":  "void",
+        "Name":  "FLD_START_FADE_DISABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10bd",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_SCH_OBJ_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10be",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_DISTANCE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10bf",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_DIFF_X_ANGLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10c0",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_DIFF_Y_ANGLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10c1",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_DIFF_Z_ANGLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10c2",
+        "ReturnType":  "float",
+        "Name":  "FLD_CAMERA_GET_X_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10c3",
+        "ReturnType":  "float",
+        "Name":  "FLD_CAMERA_GET_Y_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10c4",
+        "ReturnType":  "float",
+        "Name":  "FLD_CAMERA_GET_Z_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10c5",
+        "ReturnType":  "float",
+        "Name":  "FLD_CAMERA_GET_X_ROT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10c6",
+        "ReturnType":  "float",
+        "Name":  "FLD_CAMERA_GET_Y_ROT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10c7",
+        "ReturnType":  "float",
+        "Name":  "FLD_CAMERA_GET_Z_ROT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10c8",
+        "ReturnType":  "float",
+        "Name":  "FLD_CAMERA_GET_W_ROT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10c9",
+        "ReturnType":  "float",
+        "Name":  "FLD_CAMERA_GET_FOVY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ca",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_RELOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10cb",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_SCH_OBJ_FIX_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10cc",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_FIND_SOMETHING",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10cd",
+        "ReturnType":  "void",
+        "Name":  "FLD_PTY_FOLLOW_ENABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ce",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_SET_FIXED",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param7",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10cf",
+        "ReturnType":  "void",
+        "Name":  "FLD_SCH_OBJ_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10d0",
+        "ReturnType":  "void",
+        "Name":  "FLD_START_BOSS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10d1",
+        "ReturnType":  "void",
+        "Name":  "FLD_RETRY_CLEAR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10d2",
+        "ReturnType":  "void",
+        "Name":  "FLD_RETRY_BOSS_SAVE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10d3",
+        "ReturnType":  "void",
+        "Name":  "FLD_RETRY_BOSS_LOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10d4",
+        "ReturnType":  "void",
+        "Name":  "FLD_RETRY_BOSS_CLEAR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10d5",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_PREV_MAJOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10d6",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_PREV_MINOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10d7",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_PREV_POS_INDEX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10d8",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_BEHIND_LOCK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10d9",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_BEHIND_UNLOCK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10da",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_SET_PARAM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param7",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10db",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_RESET_PARAM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10dc",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_COVER_STATE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10dd",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_ATTACH_MODEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10de",
+        "ReturnType":  "int",
+        "Name":  "FLD_PC_ID_GET_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10df",
+        "ReturnType":  "int",
+        "Name":  "FLD_PC_ID_CHECK_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10e0",
+        "ReturnType":  "void",
+        "Name":  "FLD_PAUSE_ENEMY_MOVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10e1",
+        "ReturnType":  "void",
+        "Name":  "FLD_RESUME_ENEMY_MOVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10e2",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_FREE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10e3",
+        "ReturnType":  "void",
+        "Name":  "CALL_AT_DUNGEON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10e4",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_DOOR_DIR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10e5",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_LIST_ON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10e6",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_LIST_OFF",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10e7",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_WALK_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10e8",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_RUN_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10e9",
+        "ReturnType":  "int",
+        "Name":  "FLD_MODEL_ADDMOTION_LOAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ea",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_COPY_POSE_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10eb",
+        "ReturnType":  "int",
+        "Name":  "FLD_MODEL_CLONE_ADDMOTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ec",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_REVERT_ADDMOTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ed",
+        "ReturnType":  "void",
+        "Name":  "FLD_START_BGM_DISABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ee",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_POINT_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ef",
+        "ReturnType":  "int",
+        "Name":  "FLD_ENCOUNT_SYMBOL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10f0",
+        "ReturnType":  "int",
+        "Name":  "FLD_SEARCH_CLOSEST_ENEMY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10f1",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_WANTED_POINT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10f2",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_WANTED_POINT",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10f3",
+        "ReturnType":  "void",
+        "Name":  "FLD_ADD_WANTED_POINT",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10f4",
+        "ReturnType":  "int",
+        "Name":  "FLD_ENCOUNT_SYMBOL_FADE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10f5",
+        "ReturnType":  "int",
+        "Name":  "CALL_LMAP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10f6",
+        "ReturnType":  "void",
+        "Name":  "FLD_START_FADE_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10f7",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_MODEL_LOAD_BASE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10f8",
+        "ReturnType":  "int",
+        "Name":  "FLD_DNG_CHK_ACCIDENT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10f9",
+        "ReturnType":  "int",
+        "Name":  "FLD_ENCOUNT_SYMBOL_CLOSE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10fa",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_BOSS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10fb",
+        "ReturnType":  "void",
+        "Name":  "FLD_WEAPON_MODEL_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10fc",
+        "ReturnType":  "void",
+        "Name":  "FLD_GUN_MODEL_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10fd",
+        "ReturnType":  "void",
+        "Name":  "FLD_CELLPHONE_MODEL_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10fe",
+        "ReturnType":  "void",
+        "Name":  "FLD_BAG_MODEL_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x10ff",
+        "ReturnType":  "void",
+        "Name":  "FLD_UMBRELLA_MODEL_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1100",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_LMAP_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1101",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_ENEMY_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1102",
+        "ReturnType":  "void",
+        "Name":  "FLD_TUTORIAL_OK_ONLY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1103",
+        "ReturnType":  "int",
+        "Name":  "FLD_CLOSE_DOOR_NO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1104",
+        "ReturnType":  "void",
+        "Name":  "FLD_LOCAL_FLAG_ON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1105",
+        "ReturnType":  "void",
+        "Name":  "FLD_LOCAL_FLAG_OFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1106",
+        "ReturnType":  "int",
+        "Name":  "FLD_LOCAL_FLAG_CHK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1107",
+        "ReturnType":  "void",
+        "Name":  "FLD_REQ_SCN_CHANGE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1108",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_TRANSLATION_KEY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1109",
+        "ReturnType":  "void",
+        "Name":  "FLD_HIT_SET_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x110a",
+        "ReturnType":  "void",
+        "Name":  "FLD_HIT_RESET_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x110b",
+        "ReturnType":  "int",
+        "Name":  "FLD_HIT_GET_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x110c",
+        "ReturnType":  "int",
+        "Name":  "FLD_HIT_GET_NAMEID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x110d",
+        "ReturnType":  "void",
+        "Name":  "FLD_SOBJHIT_SET_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x110e",
+        "ReturnType":  "void",
+        "Name":  "FLD_SOBJHIT_RESET_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x110f",
+        "ReturnType":  "int",
+        "Name":  "FLD_SOBJHIT_GET_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1110",
+        "ReturnType":  "int",
+        "Name":  "FLD_SOBJHIT_GET_NAMEID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1111",
+        "ReturnType":  "void",
+        "Name":  "FLD_PLACE_NAME_SET_NO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1112",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_SEARCH_RESHND2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1113",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_REMOVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1114",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_STOP_CHASE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1115",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_CHECK_CHASE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1116",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_ZOOM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1117",
+        "ReturnType":  "void",
+        "Name":  "FLD_PLACENAME_TEX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1118",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_START_CHASE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1119",
+        "ReturnType":  "void",
+        "Name":  "FLD_UNIT_SET_COLLIS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x111a",
+        "ReturnType":  "int",
+        "Name":  "FLD_NOT_OPEN_DOOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x111b",
+        "ReturnType":  "int",
+        "Name":  "FLD_OPEN_DOOR_FADE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x111c",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_SET_LOOKAT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x111d",
+        "ReturnType":  "void",
+        "Name":  "FLD_OPEN_TBOX_SIMPLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x111e",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DIVDATA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x111f",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_DIVDATA",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1120",
+        "ReturnType":  "void",
+        "Name":  "FLD_UPDATE_DIVDATA",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1121",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_SCH_OBJ_RND_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1122",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_UNIT_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1123",
+        "ReturnType":  "int",
+        "Name":  "FLD_OPEN_FRIDGE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1124",
+        "ReturnType":  "void",
+        "Name":  "FLD_CLOSE_FRIDGE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1125",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_PRGANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1126",
+        "ReturnType":  "int",
+        "Name":  "FLD_PC_GET_CURRENT_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1127",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPCID_SEARCH_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1128",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPCID_SEARCH_RESHND2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1129",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_DIV_INDEX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x112a",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_PREV_DIV_INDEX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x112b",
+        "ReturnType":  "void",
+        "Name":  "FLD_SWITCH_ON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x112c",
+        "ReturnType":  "void",
+        "Name":  "FLD_GET_SCH_OBJ_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x112d",
+        "ReturnType":  "float",
+        "Name":  "FLD_POS_GET_X_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x112e",
+        "ReturnType":  "float",
+        "Name":  "FLD_POS_GET_Y_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x112f",
+        "ReturnType":  "float",
+        "Name":  "FLD_POS_GET_Z_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1130",
+        "ReturnType":  "void",
+        "Name":  "FLD_SFTYROOM_MENU",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1131",
+        "ReturnType":  "void",
+        "Name":  "FLD_SFTYROOM_MENU_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1132",
+        "ReturnType":  "void",
+        "Name":  "FLD_SFTYROOM_MENU_EXIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1133",
+        "ReturnType":  "void",
+        "Name":  "FLD_SFTYROOM_MENU_SETMASK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1134",
+        "ReturnType":  "void",
+        "Name":  "FLD_GREETING_MSG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1135",
+        "ReturnType":  "void",
+        "Name":  "FLD_GREETING_MSGSYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1136",
+        "ReturnType":  "void",
+        "Name":  "FLD_GREETING_FREE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1137",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_GET_DISTANCE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1138",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_INTERP_SMOOTH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1139",
+        "ReturnType":  "void",
+        "Name":  "CALL_KF_EVENT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x113a",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_MORGANA_BAG",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x113b",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_COVER_RUN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x113c",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_SYNC_COVER_RUN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x113d",
+        "ReturnType":  "int",
+        "Name":  "FLD_SNUFF_GET_RESULT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x113e",
+        "ReturnType":  "void",
+        "Name":  "FLD_PTY_MODEL_SET_STD_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x113f",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_TUMBLE_INTERP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param7",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1140",
+        "ReturnType":  "void",
+        "Name":  "FLD_PTY_MODEL_SET_PAUSE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1141",
+        "ReturnType":  "void",
+        "Name":  "FLD_DUNGEON_RESULT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1142",
+        "ReturnType":  "void",
+        "Name":  "FLD_DUNGEON_RESULT_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1143",
+        "ReturnType":  "void",
+        "Name":  "FLD_CROWD_SET_MESSAGE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1144",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_HIT_UPDATE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1145",
+        "ReturnType":  "void",
+        "Name":  "FLD_UNIT_WAIT_DISABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1146",
+        "ReturnType":  "void",
+        "Name":  "FLD_SFTYROOM_SET_CAMERA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1147",
+        "ReturnType":  "void",
+        "Name":  "FLD_SFTYROOM_MENU_SETHELP",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1148",
+        "ReturnType":  "void",
+        "Name":  "FLD_BG_TRANSKEY_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1149",
+        "ReturnType":  "void",
+        "Name":  "FLD_RESET_SCH_OBJ_FLAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x114a",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_ACTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x114b",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x114c",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_ROTATE_RESET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x114d",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_ROTATE_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x114e",
+        "ReturnType":  "void",
+        "Name":  "FLD_EFFECT_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x114f",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHOICE_REPORTER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1150",
+        "ReturnType":  "int",
+        "Name":  "FLD_PC_GET_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1151",
+        "ReturnType":  "void",
+        "Name":  "FLD_UNIT_SET_WAIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1152",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_TBOX_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1153",
+        "ReturnType":  "void",
+        "Name":  "FLD_OVERTURN_TAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1154",
+        "ReturnType":  "void",
+        "Name":  "FLD_SMP_EVENT_BEGIN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1155",
+        "ReturnType":  "void",
+        "Name":  "FLD_SMP_EVENT_END",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1156",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_LIST_INVISALL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1157",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_LIST_VISITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1158",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_LIST_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1159",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_LIST_INVIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x115a",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_LIST_SYNC_VIS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x115b",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_REPORTER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x115c",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_FOUND_ENEMY_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x115d",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_SET_FIXED_REVERT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param7",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param8",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x115e",
+        "ReturnType":  "void",
+        "Name":  "FLD_ALERT_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x115f",
+        "ReturnType":  "int",
+        "Name":  "FLD_ALERT_GET_VISIBLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1160",
+        "ReturnType":  "int",
+        "Name":  "FLD_TUTORIAL_COVER_RUN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1161",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_GET_CURRENT_PATHNODE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1162",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_STOP_PATHNODE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1163",
+        "ReturnType":  "void",
+        "Name":  "FLD_GET_STAMP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1164",
+        "ReturnType":  "void",
+        "Name":  "FLD_EXIT_DUNGEON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1165",
+        "ReturnType":  "void",
+        "Name":  "FLD_TOOL_CREATE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1166",
+        "ReturnType":  "void",
+        "Name":  "FLD_TOOL_CREATE_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1167",
+        "ReturnType":  "int",
+        "Name":  "FLD_PERSONA_MODEL_LOAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1168",
+        "ReturnType":  "void",
+        "Name":  "FLD_TOOL_SCR_YESNO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1169",
+        "ReturnType":  "int",
+        "Name":  "FLD_TOOL_GET_ELEMENTID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x116a",
+        "ReturnType":  "void",
+        "Name":  "FLD_PTY_MODEL_SET_HIDE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x116b",
+        "ReturnType":  "void",
+        "Name":  "FLD_EXIT_TIME_DISP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x116c",
+        "ReturnType":  "void",
+        "Name":  "FLD_SYNC_TIME_DISP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x116d",
+        "ReturnType":  "void",
+        "Name":  "SAVE_TEMPORARY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x116e",
+        "ReturnType":  "int",
+        "Name":  "LOAD_TEMPORARY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x116f",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_SET_RUNSTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1170",
+        "ReturnType":  "void",
+        "Name":  "FLD_RAIN_PAUSE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1171",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_READRESUME_DISABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1172",
+        "ReturnType":  "void",
+        "Name":  "FLD_CROWD_INTERCEPT_READ",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1173",
+        "ReturnType":  "int",
+        "Name":  "FLD_TOOL_ACCOUNT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1174",
+        "ReturnType":  "void",
+        "Name":  "FLD_HITSCR_FORCE_EXEC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1175",
+        "ReturnType":  "void",
+        "Name":  "FLD_ALERT_HOLD_OFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1176",
+        "ReturnType":  "void",
+        "Name":  "FLD_STOP_FLASHBACK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1177",
+        "ReturnType":  "int",
+        "Name":  "FLD_MODEL_TYPMOTION_LOAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1178",
+        "ReturnType":  "int",
+        "Name":  "FLD_MODEL_CLONE_TYPMOTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1179",
+        "ReturnType":  "void",
+        "Name":  "FLD_UNIT_SET_WALK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x117a",
+        "ReturnType":  "void",
+        "Name":  "FLD_UNIT_SET_RUN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x117b",
+        "ReturnType":  "void",
+        "Name":  "FLD_UNIT_SET_C_WAIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x117c",
+        "ReturnType":  "void",
+        "Name":  "FLD_UNIT_SET_C_RUN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x117d",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_TBLID_LOAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x117e",
+        "ReturnType":  "void",
+        "Name":  "FLD_ESCAPE_EFFECT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x117f",
+        "ReturnType":  "float",
+        "Name":  "FLD_POS_GET_ROT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1180",
+        "ReturnType":  "float",
+        "Name":  "FLD_POS_GET_DNG_X_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1181",
+        "ReturnType":  "float",
+        "Name":  "FLD_POS_GET_DNG_Y_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1182",
+        "ReturnType":  "float",
+        "Name":  "FLD_POS_GET_DNG_Z_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1183",
+        "ReturnType":  "float",
+        "Name":  "FLD_POS_GET_DNG_ROT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1184",
+        "ReturnType":  "void",
+        "Name":  "FLD_BGMNG_LINKPROC_TIME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1185",
+        "ReturnType":  "void",
+        "Name":  "FLD_BGMNG_LINKPROC_ANIMSTART",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1186",
+        "ReturnType":  "void",
+        "Name":  "FLD_BGMNG_LINKPROC_ANIMEND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1187",
+        "ReturnType":  "void",
+        "Name":  "FLD_SWITCH_OFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1188",
+        "ReturnType":  "int",
+        "Name":  "FLD_CORP_NPC_EXIST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1189",
+        "ReturnType":  "int",
+        "Name":  "FLD_CORP_NPC_EXIST2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x118a",
+        "ReturnType":  "int",
+        "Name":  "FLD_OBJ_SEARCH_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x118b",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_FOG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param7",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x118c",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_FOG_DEFAULT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x118d",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_ANIM_BLINK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x118e",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_WEAPON_CHANGE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x118f",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_FIND_ENEMY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  "Alias of 0x1211 FLD_CHECK_FIND_ENEMY"
+    },
+    {
+        "Index":  "0x1190",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_PAD_LOCK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1191",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_RAY_HIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1192",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_SUBJECT_MODE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1193",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_CORRECT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1194",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_CORRECT_DEFAULT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1195",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_REQ_WIRE_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1196",
+        "ReturnType":  "void",
+        "Name":  "FLD_START_ATDNG_SHOP_ENTER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1197",
+        "ReturnType":  "void",
+        "Name":  "FLD_OBJ_POL_RELOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1198",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_ATTACH_MODEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1199",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_MOVE_LOCK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x119a",
+        "ReturnType":  "void",
+        "Name":  "FLD_SYNC_ENV",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x119b",
+        "ReturnType":  "void",
+        "Name":  "FLD_GMC_PUZZLE_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x119c",
+        "ReturnType":  "void",
+        "Name":  "FLD_GMC_PUZZLE_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x119d",
+        "ReturnType":  "int",
+        "Name":  "FLD_GMC_PUZZLE_PARAM_CMD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x119e",
+        "ReturnType":  "void",
+        "Name":  "FLD_UMBRELLA_ANIM_CHANGE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x119f",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_STOP_NOW",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11a0",
+        "ReturnType":  "void",
+        "Name":  "FLD_LMAP_FADE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11a1",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_SET_RUNSTATE2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11a2",
+        "ReturnType":  "void",
+        "Name":  "FLD_CROWD_PATH_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11a3",
+        "ReturnType":  "void",
+        "Name":  "FLD_CROWD_PATH_WAIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11a4",
+        "ReturnType":  "int",
+        "Name":  "FLD_CROWD_PATH_CHECK_UNIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11a5",
+        "ReturnType":  "void",
+        "Name":  "FLD_CROWD_PATH_REPOP_UNIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11a6",
+        "ReturnType":  "void",
+        "Name":  "FLD_CROWD_PATH_INTERCEPT_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11a7",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_LOCAL_COUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11a8",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_LOCAL_COUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11a9",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DOOR_HIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11aa",
+        "ReturnType":  "void",
+        "Name":  "FLD_REPORT_MSG_DTL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ab",
+        "ReturnType":  "void",
+        "Name":  "FLD_REPORT_MSGSYNC_DTL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ac",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_UNIT_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ad",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_UNIT_POINT_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ae",
+        "ReturnType":  "void",
+        "Name":  "FLD_TOOL_SET_ITEM_NAME",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11af",
+        "ReturnType":  "int",
+        "Name":  "FLD_TOOL_CHK_ITEM_AVAILABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11b0",
+        "ReturnType":  "void",
+        "Name":  "FLD_TOOL_CREATE_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11b1",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_LOOK_AROUND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11b2",
+        "ReturnType":  "void",
+        "Name":  "FLD_DUNGEON_RESULT_SET_MES",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11b3",
+        "ReturnType":  "void",
+        "Name":  "FLD_DUNGEON_RESULT_CLEAR_MES",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11b4",
+        "ReturnType":  "void",
+        "Name":  "FLD_DUNGEON_RESULT_SET_VAR",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11b5",
+        "ReturnType":  "void",
+        "Name":  "FLD_DUNGEON_RESULT_CLEAR_VAR",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11b6",
+        "ReturnType":  "int",
+        "Name":  "FLD_DUNGEON_RESULT_GET_TOTALPRICE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11b7",
+        "ReturnType":  "int",
+        "Name":  "FLD_CROWD_PATH_WAIT_UNIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11b8",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_REQ_ACTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11b9",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_SYNC_ACTION",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ba",
+        "ReturnType":  "void",
+        "Name":  "FLD_GMC_OBJ_MOVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11bb",
+        "ReturnType":  "void",
+        "Name":  "FLD_GMC_OBJ_MOVE_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11bc",
+        "ReturnType":  "void",
+        "Name":  "FLD_GMC_TENKEY_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11bd",
+        "ReturnType":  "int",
+        "Name":  "FLD_GMC_TENKEY_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11be",
+        "ReturnType":  "void",
+        "Name":  "FLD_GMC_TENKEY_END",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11bf",
+        "ReturnType":  "int",
+        "Name":  "FLD_GMC_TENKEY_CTRL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11c0",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_MOUSE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11c1",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_MOUSE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11c2",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_PTYTALK_MSG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11c3",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_PTYTALK_WND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11c4",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_PTYTALK_FACE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11c5",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_LOCK_INTERP_S",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param7",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param8",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11c6",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_BATTLE_RESULT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11c7",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_APPROACH_ENEMY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11c8",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHOICE_MEMBER_REPORTER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11c9",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_GET_MAJOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ca",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_GET_MINOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11cb",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_GET_POS_INDEX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11cc",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_GET_DIV_INDEX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11cd",
+        "ReturnType":  "void",
+        "Name":  "FLD_REQ_PC_SE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ce",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_EXIST_GROUP_VALUE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11cf",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_EXIST_GROUP_VALUE_MD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11d0",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_BIT_CHK_GROUP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11d1",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_CARTALK_THEME",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11d2",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_INIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11d3",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_INIT_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11d4",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_RESET_TAKEOUT_INFO",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11d5",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_SET_TAKEOUT_INFO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11d6",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_TAKEOUT_CATEGORY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11d7",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_TAKEOUT_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11d8",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_CHECK_TAKEOUT_INFO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11d9",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_EVALUATION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11da",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_BONUS_TYPE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11db",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_CHECK_BONUS_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11dc",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_REWARD_TYPE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11dd",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_REWARD_VALUE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11de",
+        "ReturnType":  "void",
+        "Name":  "FLD_TOOL_USE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11df",
+        "ReturnType":  "void",
+        "Name":  "FLD_TOOL_VIEW",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11e0",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_PC_PARAM_ADD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11e1",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_SCR_SKIP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11e2",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_SCR_SKIP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11e3",
+        "ReturnType":  "void",
+        "Name":  "FLD_WAIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11e4",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x0017 MDL_ANIM"
+    },
+    {
+        "Index":  "0x11e5",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_ANIM_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x0018 MDL_ANIM_SYNC"
+    },
+    {
+        "Index":  "0x11e6",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_SET_GLIMPSE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11e7",
+        "ReturnType":  "int",
+        "Name":  "FLD_TOOL_GET_ITEMID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11e8",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_FBN_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11e9",
+        "ReturnType":  "int",
+        "Name":  "FLD_SEL_EX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ea",
+        "ReturnType":  "void",
+        "Name":  "FLD_SEL_SET_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11eb",
+        "ReturnType":  "int",
+        "Name":  "FLD_SEL_DATA_REQUEST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ec",
+        "ReturnType":  "void",
+        "Name":  "FLD_MAP_PANEL_CHANGE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ed",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_SET_MSG_INFO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ee",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_MSG_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ef",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_MSG_NUM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11f0",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_LOOK_FRONT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11f1",
+        "ReturnType":  "void",
+        "Name":  "FLD_START_DEBUG_SCRIPT",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11f2",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_DIR_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11f3",
+        "ReturnType":  "void",
+        "Name":  "FLD_SHOW_ENEMY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11f4",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_BONUS_TYPE_NUM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11f5",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_SET_FAVORABILITY_FLAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11f6",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_FAVORABILITY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11f7",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_BONUS_FORMATION_COUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11f8",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_RESET_MSG_INFO",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11f9",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_RESET_DESIGNATION_MENU",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11fa",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_SET_DESIGNATION_MENU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11fb",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_RAND_DESIGNATION_MENU",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11fc",
+        "ReturnType":  "void",
+        "Name":  "FLD_LMAP_END",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11fd",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_ATTACH_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11fe",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_DETACH_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x11ff",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_ATTACH_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1200",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_DETACH_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1201",
+        "ReturnType":  "void",
+        "Name":  "FLD_REQ_PRE_LOAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1202",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_SET_VAR_FOOD_NAME",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1203",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_TALK_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1204",
+        "ReturnType":  "void",
+        "Name":  "FLD_UNIT_SET_SURPRISE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1205",
+        "ReturnType":  "void",
+        "Name":  "FLD_GAYA_EFFECT_SET",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1206",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_ACCEPT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1207",
+        "ReturnType":  "int",
+        "Name":  "FLD_LMAP_GET_FARE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1208",
+        "ReturnType":  "void",
+        "Name":  "CALL_BATTING_CENTER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1209",
+        "ReturnType":  "void",
+        "Name":  "FLD_GREETING_MSG_DTL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x120a",
+        "ReturnType":  "int",
+        "Name":  "FLD_CROWD_PATH_READ_WAIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x120b",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_FOOD_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x120c",
+        "ReturnType":  "void",
+        "Name":  "FLD_DUNGEON_RESULT_SET_EXP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x120d",
+        "ReturnType":  "void",
+        "Name":  "FLD_HIT_ADD_ICON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x120e",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_FOOD_ALL_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x120f",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_DISH_CLONE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1210",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_SMK_BALL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1211",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_FIND_ENEMY___2",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  "Alias of 0x118f FLD_CHECK_FIND_ENEMY"
+    },
+    {
+        "Index":  "0x1212",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_MAP_PROC_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1213",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_MAP_PROC_END",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1214",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_DISH_CLONE_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1215",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_SCALE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1216",
+        "ReturnType":  "void",
+        "Name":  "FLD_TOOL_SET_DRAWFLAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1217",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_SET_FLOATING",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1218",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_MOVE_FLOATING",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1219",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_SYNC_FLOATING",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x121a",
+        "ReturnType":  "void",
+        "Name":  "CALL_FISHING_POND",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x121b",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_DISH_DRAWSET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x121c",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_DISTANCE_X",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x121d",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_181_GET_DISTANCE_Z",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x121e",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_GREETING_GET_DISP_TIME",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x121f",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DISGUISE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1220",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_DISGUISE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1221",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_PERSONAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1222",
+        "ReturnType":  "void",
+        "Name":  "FLD_OBJ_SET_ALPHA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1223",
+        "ReturnType":  "int",
+        "Name":  "FLD_PANEL_MMAP_WHOLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1224",
+        "ReturnType":  "int",
+        "Name":  "FLD_PANEL_MAP_AT_CHECK_VISIBLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1225",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_SET_NANPA_TACTICS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1226",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DEBUG_OK",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1227",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_GET_NANPA_QUEST_VAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1228",
+        "ReturnType":  "void",
+        "Name":  "FLD_FASTTRAVEL_OPEN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1229",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_SET_RIPPLE_EFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x122a",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_SET_SPOUT_EFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x122b",
+        "ReturnType":  "void",
+        "Name":  "FLD_GET_FIX_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x122c",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_GET_NANPA_BEST_SEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x122d",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_NANPA_BITON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x122e",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_NANPA_BITCHECK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x122f",
+        "ReturnType":  "void",
+        "Name":  "FLD_REQ_DOOR_SE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1230",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_181_DISH_EFFECT",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1231",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_ENEMY_WAIT_TIME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1232",
+        "ReturnType":  "void",
+        "Name":  "FLD_OVERWRITE_ENC_NO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1233",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_LOOK_AT_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1234",
+        "ReturnType":  "void",
+        "Name":  "FLD_PTY_MODEL_SET_RND_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1235",
+        "ReturnType":  "void",
+        "Name":  "FLD_PTY_MODEL_SET_LINE_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1236",
+        "ReturnType":  "void",
+        "Name":  "FLD_OPEN_ORD_DOOR_ONLY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1237",
+        "ReturnType":  "int",
+        "Name":  "FLD_MISSION_ACCEPT_GET_CHECK_NUM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1238",
+        "ReturnType":  "int",
+        "Name":  "FLD_MISSION_ACCEPT_GET_CHECK_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1239",
+        "ReturnType":  "int",
+        "Name":  "FLD_SUMMON_ENEMY_MOVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x123a",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_LIST_ON_FORCE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x123b",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_SCH_OBJ_ENEMY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x123c",
+        "ReturnType":  "void",
+        "Name":  "FLD_TOOL_REQUEST_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x123d",
+        "ReturnType":  "int",
+        "Name":  "FLD_PC_GET_BAG_TYPE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x123e",
+        "ReturnType":  "void",
+        "Name":  "FLD_OPEN_ORD_DOOR_FADE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x123f",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DOOR_HIT_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1240",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_ENEMY_GLANCE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1241",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_SEPARATEOFF_MESH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1242",
+        "ReturnType":  "void",
+        "Name":  "FLD_PARTY_IN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1243",
+        "ReturnType":  "void",
+        "Name":  "FLD_PARTY_OUT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1244",
+        "ReturnType":  "void",
+        "Name":  "FLD_REQ_PRE_LOAD_ATDNG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1245",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_ENTRANCE_FLOOR",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1246",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_SAFE_ROOM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1247",
+        "ReturnType":  "void",
+        "Name":  "FLD_SFTYROOM_MENU_SETMODE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1248",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_ANIM_NEXT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1249",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_SAVE_ENABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x124a",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DIALY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x124b",
+        "ReturnType":  "void",
+        "Name":  "FLD_DUNGEON_RESULT_SET_MVP",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x124c",
+        "ReturnType":  "void",
+        "Name":  "FLD_DUNGEON_RESULT_SET_BONUS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x124d",
+        "ReturnType":  "void",
+        "Name":  "FLD_BAG_ANIM_DISABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x124e",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_BAG_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x124f",
+        "ReturnType":  "int",
+        "Name":  "FLD_SYNC_DOOR_FADE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1250",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_DNG_TRAVERSE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1251",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_SYMBOL_ENCOUNTID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1252",
+        "ReturnType":  "void",
+        "Name":  "FLD_DUNGEON_RESULT_SET_DUNGEON_NO",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1253",
+        "ReturnType":  "void",
+        "Name":  "FLD_SYNC_GET_ITEM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1254",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_RESET_FBNID_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1255",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_TBL_GET_MAJOR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1256",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_TBL_GET_MINOR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1257",
+        "ReturnType":  "int",
+        "Name":  "KFEVT_TBL_GET_DIV",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1258",
+        "ReturnType":  "int",
+        "Name":  "FLD_MISSION_ACCEPT_GET_SELECT_ID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1259",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_DNG_QUEST_NO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x125a",
+        "ReturnType":  "void",
+        "Name":  "CALL_ATDNG_QUEST_FLOOR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x125b",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_TURN_AT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x125c",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_TURN_RESET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x125d",
+        "ReturnType":  "float",
+        "Name":  "FLD_GET_DNG_PARTS_ROT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x125e",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_UNDISP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x125f",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_ALERT_ADD_VALUE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1260",
+        "ReturnType":  "void",
+        "Name":  "FLD_BREAK_WALL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1261",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_SNEAKING_ITEM_ID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1262",
+        "ReturnType":  "void",
+        "Name":  "FLD_TOOL_END_EFFECT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1263",
+        "ReturnType":  "void",
+        "Name":  "FLD_TOOL_END_EFFECT_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1264",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_MSG_DISP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1265",
+        "ReturnType":  "void",
+        "Name":  "KAWAKAMI_SET_REQUEST_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1266",
+        "ReturnType":  "int",
+        "Name":  "KAWAKAMI_GET_REQUEST_ITEMID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1267",
+        "ReturnType":  "int",
+        "Name":  "KAWAKAMI_GET_REQUEST_ITEMNUM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1268",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_RESHND_BANK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1269",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_RESHND_BANK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x126a",
+        "ReturnType":  "void",
+        "Name":  "FLD_SFTYROOM_MENU_SETBOSSID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x126b",
+        "ReturnType":  "void",
+        "Name":  "FLD_DASH_EFFECT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x126c",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_CARTALK_PC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x126d",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_CARTALK_MSG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x126e",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_CARTALK_WND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x126f",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_CARTALK_FACE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1270",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_CARTALK_ANSWER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1271",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_CARTALK_ANS_PC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1272",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_CARTALK_ANS_MSG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1273",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_CARTALK_ANS_WND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1274",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_CARTALK_ANS_FACE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1275",
+        "ReturnType":  "int",
+        "Name":  "FLD_RESIDENT_EFFECT_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1276",
+        "ReturnType":  "int",
+        "Name":  "GET_CHARA_CAMERA_DIR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1277",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_SAVE_DATA_LOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1278",
+        "ReturnType":  "void",
+        "Name":  "FLD_GFS_PARTS_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1279",
+        "ReturnType":  "void",
+        "Name":  "FLD_CROWD_PAUSE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x127a",
+        "ReturnType":  "void",
+        "Name":  "FLD_CALL_EVENT_SETUP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x127b",
+        "ReturnType":  "void",
+        "Name":  "FLD_ALERT_DISP_PLACENO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x127c",
+        "ReturnType":  "void",
+        "Name":  "FLD_ALERT_RAPID_DISP_PLACENO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x127d",
+        "ReturnType":  "void",
+        "Name":  "CROSSWORD_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x127e",
+        "ReturnType":  "void",
+        "Name":  "CROSSWORD_ENDSYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x127f",
+        "ReturnType":  "int",
+        "Name":  "CROSSWORD_RELUST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1280",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_SCR_NAME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1281",
+        "ReturnType":  "int",
+        "Name":  "FLD_MISSION_LIST_GET_FLAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1282",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_LIST_SET_FLAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1283",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_LIST_CLEAR_FLAGS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1284",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_LIST_SWAPTBL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1285",
+        "ReturnType":  "void",
+        "Name":  "CALL_TV_PROGRAM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1286",
+        "ReturnType":  "void",
+        "Name":  "TV_PROGRAM_ENDSYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1287",
+        "ReturnType":  "void",
+        "Name":  "TODAY_TV_PROGRAM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1288",
+        "ReturnType":  "void",
+        "Name":  "TODAY_TV_PROGRAM_ENDSYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1289",
+        "ReturnType":  "int",
+        "Name":  "GET_TODAY_TV_PROGRAM_BG",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x128a",
+        "ReturnType":  "void",
+        "Name":  "FLD_VLT_FILTER_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x128b",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_SET_EFFECT_TARGET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x128c",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_WINDOW",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x128d",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_ALERT_DEC_VALUE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x128e",
+        "ReturnType":  "void",
+        "Name":  "FLD_VLT_FILTER_LOCK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x128f",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_DNG_FIND_PARTS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1290",
+        "ReturnType":  "void",
+        "Name":  "FLD_ALERT_SET_KEEP_FLAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1291",
+        "ReturnType":  "void",
+        "Name":  "FLD_BG_CASH_REMOVE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1292",
+        "ReturnType":  "int",
+        "Name":  "FLD_ITEM_MODEL_LOAD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1293",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_MMAP_NEW_STAGE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1294",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_MMAP_NEW_STAGE_EXIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1295",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_VISIBLE_ALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1296",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_SET_RADIUS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1297",
+        "ReturnType":  "void",
+        "Name":  "FLD_CROWD_PATH_VISIBLE_ALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1298",
+        "ReturnType":  "void",
+        "Name":  "FLD_START_SUPPORT_MSG_EX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1299",
+        "ReturnType":  "void",
+        "Name":  "FLD_SHOW_NEW_SPOT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x129a",
+        "ReturnType":  "void",
+        "Name":  "FLD_TRANS_END_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x129b",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROTATE_END_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x129c",
+        "ReturnType":  "void",
+        "Name":  "FLD_END_SMK_BALL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x129d",
+        "ReturnType":  "int",
+        "Name":  "FLD_ITEM_GET_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x129e",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_LOOKAT_DISABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x129f",
+        "ReturnType":  "void",
+        "Name":  "FLD_SETBANK_BGENV_VOICE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12a0",
+        "ReturnType":  "void",
+        "Name":  "FLD_GET_FIX_ITEMS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12a1",
+        "ReturnType":  "void",
+        "Name":  "FLD_SLIDING_EFFECT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12a2",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_TBOX_ITEM_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12a3",
+        "ReturnType":  "void",
+        "Name":  "FLD_GET_SCH_OBJ_BEGIN_NG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12a4",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_EXTRA_LIFE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12a5",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_EXTRA_LOOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12a6",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_EXTRA_END_REQ",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12a7",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_EXTRA_END_REQ_RAPID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12a8",
+        "ReturnType":  "int",
+        "Name":  "FLD_PANEL_EXTRA_CHK_VISIBLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12a9",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_APPEND_LOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12aa",
+        "ReturnType":  "void",
+        "Name":  "FLD_SLEEP_ENEMY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ab",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_SET_DEFMOTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ac",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_CANCEL_ENGULF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ad",
+        "ReturnType":  "int",
+        "Name":  "FLD_SEL_EX2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param7",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ae",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_SET_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12af",
+        "ReturnType":  "void",
+        "Name":  "FLD_GIMMICK_RAY_HIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12b0",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_CNV_NPC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12b1",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_EVT_EMY_ENCOUNT_NO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12b2",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_ENEMY_INOUT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12b3",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_EMOTE_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12b4",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAR_ONOFF_CHANGE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12b5",
+        "ReturnType":  "void",
+        "Name":  "FLD_PARTY_SAVE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12b6",
+        "ReturnType":  "void",
+        "Name":  "FLD_PARTY_LOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12b7",
+        "ReturnType":  "float",
+        "Name":  "FLD_GET_DNG_PARTS_X_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12b8",
+        "ReturnType":  "float",
+        "Name":  "FLD_GET_DNG_PARTS_Y_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12b9",
+        "ReturnType":  "float",
+        "Name":  "FLD_GET_DNG_PARTS_Z_POS",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ba",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_SET_TGT_UPDATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12bb",
+        "ReturnType":  "void",
+        "Name":  "FLD_SHOW_NEW_SPOT_SYNC_MODE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12bc",
+        "ReturnType":  "void",
+        "Name":  "FLD_SHOW_NEW_SPOT_SYNC_EXIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12bd",
+        "ReturnType":  "void",
+        "Name":  "FLD_REVERT_ENC_NO",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12be",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_ALL_ENCOUNT_NO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12bf",
+        "ReturnType":  "void",
+        "Name":  "FLD_EMY_SET_EFFECT_TARGET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12c0",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_SCNLIGHT_AMB",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12c1",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_SCNLIGHT_DIFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12c2",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_SCNLIGHT_SPEC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12c3",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_SCNLIGHT_DEFAULT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12c4",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_CHARLIGHT_AMB",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12c5",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_CHARLIGHT_DIFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12c6",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_CHARLIGHT_SPEC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12c7",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_CHARIGHT_DEFAULT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12c8",
+        "ReturnType":  "float",
+        "Name":  "FLD_CAMERA_GET_YAW",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12c9",
+        "ReturnType":  "float",
+        "Name":  "FLD_CAMERA_GET_PITCH",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ca",
+        "ReturnType":  "float",
+        "Name":  "FLD_CAMERA_GET_ROLL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12cb",
+        "ReturnType":  "float",
+        "Name":  "FLD_ADJUST_DEG_180",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12cc",
+        "ReturnType":  "int",
+        "Name":  "FLD_PC_ID_GET_CURRENT_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12cd",
+        "ReturnType":  "void",
+        "Name":  "CALL_ALERT_SPECIAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ce",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_TYPE_ALERT_VALUE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12cf",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_TYPE_ALERT_VALUE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12d0",
+        "ReturnType":  "int",
+        "Name":  "FLD_LMAP_GET_SELECT_ID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12d1",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_FIX_BGM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12d2",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_LOOKAT_DISABLE_FBNID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12d3",
+        "ReturnType":  "void",
+        "Name":  "CALL_ALERT_CHANGE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12d4",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_X_WORLD_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12d5",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_Y_WORLD_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12d6",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_Z_WORLD_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12d7",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_BGHELPER_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12d8",
+        "ReturnType":  "void",
+        "Name":  "FLD_GREETING_MSG_BLOCK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12d9",
+        "ReturnType":  "void",
+        "Name":  "FLD_GIMMICK_CAMERA_SET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12da",
+        "ReturnType":  "int",
+        "Name":  "FLD_OBJ_MODEL_LOAD_UID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12db",
+        "ReturnType":  "void",
+        "Name":  "FLD_SWITCH_ELEVATOR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12dc",
+        "ReturnType":  "float",
+        "Name":  "FLD_EMY_MODEL_GET_SCALE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12dd",
+        "ReturnType":  "void",
+        "Name":  "FLD_NOT_OPEN_DOOR_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12de",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_GUIDE_HIGHLIGHT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12df",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DARK_ZONE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12e0",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_DARK_ZONE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12e1",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_COIN_SET_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12e2",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_COIN_SET_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12e3",
+        "ReturnType":  "int",
+        "Name":  "FLD_PANEL_COIN_CHECK_VISIBLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12e4",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_FISHING_RESULT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12e5",
+        "ReturnType":  "void",
+        "Name":  "PREPARE_CALL_FIELD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12e6",
+        "ReturnType":  "void",
+        "Name":  "PREPARE_CALL_KF_EVENT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12e7",
+        "ReturnType":  "void",
+        "Name":  "FLD_CLEAR_SUMMON_ENEMY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12e8",
+        "ReturnType":  "void",
+        "Name":  "FLD_CLEAR_SUMMON_LIFE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12e9",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_INTERP_ASYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ea",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_SET_PASS_GATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12eb",
+        "ReturnType":  "void",
+        "Name":  "FLD_BFIELD_LOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ec",
+        "ReturnType":  "int",
+        "Name":  "FLD_CASINO_GAME_DEAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ed",
+        "ReturnType":  "int",
+        "Name":  "FLD_CASINO_GAME_CHECK_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ee",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_BUTTON_HIT_DISABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ef",
+        "ReturnType":  "void",
+        "Name":  "FLD_ALLY_SET_POINT_ROT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12f0",
+        "ReturnType":  "void",
+        "Name":  "FLD_ALLY_SET_ORIENT_ROT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12f1",
+        "ReturnType":  "void",
+        "Name":  "FLD_SYNC_COVER_STATE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12f2",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_PARTY_LOOKAT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12f3",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_PARTY_LOOKAT_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12f4",
+        "ReturnType":  "void",
+        "Name":  "FLD_RESET_PARTY_LOOKAT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12f5",
+        "ReturnType":  "void",
+        "Name":  "FLD_ALLY_SET_WAIT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12f6",
+        "ReturnType":  "void",
+        "Name":  "FLD_PLACENAME_TEX_EXIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12f7",
+        "ReturnType":  "void",
+        "Name":  "FLD_PLACENAME_TEX_WAIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12f8",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_SET_CURRENT_PATHNODE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12f9",
+        "ReturnType":  "void",
+        "Name":  "FLD_SWITCH_REQ_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12fa",
+        "ReturnType":  "void",
+        "Name":  "FLD_SWITCH_SYNC_ANIM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12fb",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_AUTO_RECOVER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12fc",
+        "ReturnType":  "int",
+        "Name":  "FLD_USE_AUTO_RECOVER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12fd",
+        "ReturnType":  "int",
+        "Name":  "FLD_SIMPLE_SYS_MSG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12fe",
+        "ReturnType":  "void",
+        "Name":  "FLD_MEMBER_RECOVER",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x12ff",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_TALKICON_FORCEDISP_FBNID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1300",
+        "ReturnType":  "void",
+        "Name":  "FLD_DNG_SET_CENTER_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1301",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_SET_SCALE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1302",
+        "ReturnType":  "void",
+        "Name":  "FLD_CROWD_SET_DIVNO_DNG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1303",
+        "ReturnType":  "int",
+        "Name":  "FLD_CROWD_GET_DIVNO_DNG",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1304",
+        "ReturnType":  "void",
+        "Name":  "FLD_PTY_ADD_BUF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1305",
+        "ReturnType":  "void",
+        "Name":  "FLD_PTY_RESET_BUF",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1306",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DUCT_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1307",
+        "ReturnType":  "float",
+        "Name":  "FLD_GET_DUCT_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1308",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_CAMERA_DEFAULT_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1309",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_GUIDE_UNDISP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x130a",
+        "ReturnType":  "void",
+        "Name":  "FLD_GEN_FISHING_SEED",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x130b",
+        "ReturnType":  "void",
+        "Name":  "FLD_CASINO_WORK_INIT",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x130c",
+        "ReturnType":  "void",
+        "Name":  "FLD_CLEAR_COVER_STATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x130d",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_ENEMY_ORNAMENT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x130e",
+        "ReturnType":  "int",
+        "Name":  "FLD_PANEL_GUIDE_UNDISP_CHECK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x130f",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_COIN_SET_ENABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1310",
+        "ReturnType":  "int",
+        "Name":  "FLD_PANEL_COIN_CHECK_ENABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1311",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_MMAP_OPEN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1312",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_MMAP_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1313",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_MMAP_CLOSE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1314",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_CAMERA_FAR_MODE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1315",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DOOR_HIT_TYPE_DTL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1316",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_OFS_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1317",
+        "ReturnType":  "int",
+        "Name":  "FLD_FBNID_TO_NPCID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1318",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_SET_ROTATE_RATIO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1319",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_SET_FOVY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x131a",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_DST_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x131b",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAMERA_SET_FIXED_INTERP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param7",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param8",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x131c",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_GMK_CAMERA_UID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x131d",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_GMK_CAMERA_UID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x131e",
+        "ReturnType":  "void",
+        "Name":  "FLD_MMT_MAP_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x131f",
+        "ReturnType":  "void",
+        "Name":  "FLD_GREETING_MSG_DTL_HIGH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1320",
+        "ReturnType":  "void",
+        "Name":  "FLD_REQ_PITFALL_ENTER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1321",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_MMAP_CHANGE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1322",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAR_INTERCEPT_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1323",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_TALKICON_UNDISP_FBNID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1324",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAR_ADD_ENGINE_SE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1325",
+        "ReturnType":  "void",
+        "Name":  "FLD_CAR_ENGINE_SE_ENABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1326",
+        "ReturnType":  "void",
+        "Name":  "FLD_CRAFT_ITEM_TROPHY",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1327",
+        "ReturnType":  "void",
+        "Name":  "FLD_ALLY_WEAPON_SETUP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1328",
+        "ReturnType":  "void",
+        "Name":  "FLD_SYNC_SCN_CHANGE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1329",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_BKUP_FIELD_TYPE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x132a",
+        "ReturnType":  "void",
+        "Name":  "FLD_OBJ_MODEL_LINKBG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x132b",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_X_HELPER_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x132c",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_Y_HELPER_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x132d",
+        "ReturnType":  "float",
+        "Name":  "FLD_MODEL_GET_Z_HELPER_TRANSLATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x132e",
+        "ReturnType":  "void",
+        "Name":  "BGENV_LINK_BGOBJ_INDEX_ANIM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x132f",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_UPDATE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1330",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_SHADOWCAST_FBNID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1331",
+        "ReturnType":  "void",
+        "Name":  "FLD_PTY_PANEL_SET_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1332",
+        "ReturnType":  "int",
+        "Name":  "CALL_PLAY_GO_SAVE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1333",
+        "ReturnType":  "void",
+        "Name":  "FLD_CROWD_BBEFECT_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1334",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_FBN_FADE_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1335",
+        "ReturnType":  "void",
+        "Name":  "FLD_LMAP_SPOT_TROPHY_PROC",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1336",
+        "ReturnType":  "void",
+        "Name":  "FLD_MISSION_LIST_END_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1337",
+        "ReturnType":  "void",
+        "Name":  "FLD_SPOT_FLAG_SET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1338",
+        "ReturnType":  "void",
+        "Name":  "FLD_REQ_NEXT_SCN_FADE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1339",
+        "ReturnType":  "int",
+        "Name":  "FLD_UMBREALLA_CHECK_USE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x133a",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_REQ_WIRE_MOVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x133b",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_SYNC_WIRE_MOVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x133c",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_USE_PARAMUP_FUNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x133d",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_REWARD_NUM_PARAMUP_FUNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x133e",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_REWARD_ID_PARAMUP_FUNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x133f",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_TYPE_PARAMUP_REWARD_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1340",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_VALUE_PARAMUP_REWARD_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1341",
+        "ReturnType":  "int",
+        "Name":  "FLD_TOOL_GET_CREATE_NUM",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1342",
+        "ReturnType":  "void",
+        "Name":  "FLD_GAMBLING_TIME_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1343",
+        "ReturnType":  "void",
+        "Name":  "FLD_ACTHIT_SET_ICON_NG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1344",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_WIRE_TARGET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1345",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_MODEL_SET_WIRE_SPEED",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1346",
+        "ReturnType":  "void",
+        "Name":  "FLD_ENTER_BY_WALK_DISABLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1347",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_WIRE_TARGET_EFFECT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1348",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_TOTAL_STAMP_POINT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1349",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DBG_ATDNG_PROGRESS",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x134a",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_QUEST_ATDNG_PARAM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x134b",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_ADJUST_GROUND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x134c",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_SET_NPC_POS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x134d",
+        "ReturnType":  "int",
+        "Name":  "FLD_CAMERA_CHECK_LOCK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x134e",
+        "ReturnType":  "int",
+        "Name":  "FLD_SEARCH_POL_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x134f",
+        "ReturnType":  "void",
+        "Name":  "FLD_ANIM_HIT_IMMEDIATE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1350",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_BACK_LOG_LOCK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1351",
+        "ReturnType":  "int",
+        "Name":  "FLD_ASSIST_GET_DISTINATION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1352",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_GREETING_DISABLE_FBNID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1353",
+        "ReturnType":  "void",
+        "Name":  "FLD_AST_SET_REINFORCE_DATA",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1354",
+        "ReturnType":  "void",
+        "Name":  "FLD_AST_SET_COOP_DATA",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1355",
+        "ReturnType":  "int",
+        "Name":  "FLD_AST_GET_REINFORCE_INDEX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1356",
+        "ReturnType":  "int",
+        "Name":  "FLD_AST_GET_COOP_INDEX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1357",
+        "ReturnType":  "int",
+        "Name":  "FLD_AST_GET_PARAMID_FROM_RFIDX",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1358",
+        "ReturnType":  "void",
+        "Name":  "FLD_ENEMY_SET_MAD_EFFECT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1359",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_INDEX_STAMP_POINT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x135a",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_INDEX_STAMP_COUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x135b",
+        "ReturnType":  "void",
+        "Name":  "CALL_DAIFUGOU",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x135c",
+        "ReturnType":  "void",
+        "Name":  "FLD_CLEAR_COIN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x135d",
+        "ReturnType":  "void",
+        "Name":  "FLD_PARTY_STATUS_SAVE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x135e",
+        "ReturnType":  "void",
+        "Name":  "FLD_PARTY_HPSP_LOAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x135f",
+        "ReturnType":  "int",
+        "Name":  "FLD_AST_COOP_LIST_CHECK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1360",
+        "ReturnType":  "int",
+        "Name":  "FLD_AST_FACIL_LIST_CHECK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1361",
+        "ReturnType":  "void",
+        "Name":  "FLD_AST_DISPLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1362",
+        "ReturnType":  "int",
+        "Name":  "FLD_AST_FACIL_UNLOCK_CHECK",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1363",
+        "ReturnType":  "void",
+        "Name":  "SET_VTAG_HERO_CALL_PC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1364",
+        "ReturnType":  "void",
+        "Name":  "FLD_CROWD_SET_HIT_MODEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1365",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_ENEMY_INOUT_EFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1366",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_SET_MOVE_SPEED",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1367",
+        "ReturnType":  "int",
+        "Name":  "FLD_CROWD_ALL_UNMOVED_READ_WAIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1368",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_TALK_DISABLE_FBNID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1369",
+        "ReturnType":  "int",
+        "Name":  "FLD_SET_TRANSFORM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x136a",
+        "ReturnType":  "void",
+        "Name":  "FLD_START_MMT_MAP_EFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x136b",
+        "ReturnType":  "void",
+        "Name":  "FLD_END_MMT_MAP_EFF",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x136c",
+        "ReturnType":  "void",
+        "Name":  "FLD_MEMBER_RECOVER_DIRECT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x136d",
+        "ReturnType":  "void",
+        "Name":  "FLD_MY_PALACE_ENTER",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x136e",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_PARAM_ADD_ON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x136f",
+        "ReturnType":  "void",
+        "Name":  "FLD_PANEL_DISP_NO_MAP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1370",
+        "ReturnType":  "void",
+        "Name":  "FLD_PC_PARAM_ADD_DISP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1371",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_NEAR_PAUSE_DISABLE_FBNID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1372",
+        "ReturnType":  "int",
+        "Name":  "FLD_AST_CHK_SEL_HIDEOUT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1373",
+        "ReturnType":  "int",
+        "Name":  "FLD_MY_PALACE_GET_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1374",
+        "ReturnType":  "int",
+        "Name":  "FLD_CHECK_USABLE_SNEAKING_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1375",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_QR_ID",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1376",
+        "ReturnType":  "void",
+        "Name":  "FLD_DISP_QR",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1377",
+        "ReturnType":  "void",
+        "Name":  "FLD_BG_WEATHER_EFF_VISIBLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1378",
+        "ReturnType":  "void",
+        "Name":  "FLD_SE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1379",
+        "ReturnType":  "void",
+        "Name":  "FLD_DEC_SAFEROOM_ALERT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x137a",
+        "ReturnType":  "void",
+        "Name":  "FLD_UPDATE_DAYS_ALERT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x137b",
+        "ReturnType":  "void",
+        "Name":  "FLD_DAIFUGOU_SET_SEL_NO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x137c",
+        "ReturnType":  "void",
+        "Name":  "FLD_NPC_SET_NAMEID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x137d",
+        "ReturnType":  "int",
+        "Name":  "FLD_NPC_GET_NAMEID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x137e",
+        "ReturnType":  "int",
+        "Name":  "FLD_TOOL_SCR_GET_BONUS_NUM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x137f",
+        "ReturnType":  "void",
+        "Name":  "FLD_MAP_PANEL_CANCEL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1380",
+        "ReturnType":  "void",
+        "Name":  "FLD_COMSE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1381",
+        "ReturnType":  "void",
+        "Name":  "FLD_COMSE_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1382",
+        "ReturnType":  "void",
+        "Name":  "FLD_GMC_LIGHT_SET_SCRIPT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1383",
+        "ReturnType":  "int",
+        "Name":  "FLD_GMC_LIGHT_GET_VALUE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1384",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_BATTLE_FIELD",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1385",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_ANOTHER_ENV",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1386",
+        "ReturnType":  "void",
+        "Name":  "FLD_REQ_CA_RIPPLE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1387",
+        "ReturnType":  "void",
+        "Name":  "FLD_MY_PALACE_REQ_ANNOUNCE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1388",
+        "ReturnType":  "void",
+        "Name":  "FLD_START_TELOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1389",
+        "ReturnType":  "float",
+        "Name":  "FLD_GET_GROUND_Y",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x138a",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_DNG_QUEST_NO___2",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x138b",
+        "ReturnType":  "void",
+        "Name":  "FLD_SET_DEFAULT_ALERT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x138c",
+        "ReturnType":  "int",
+        "Name":  "FLD_GET_COIN_COUNT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x138d",
+        "ReturnType":  "void",
+        "Name":  "FLD_DNG_RESET_TBOX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x138e",
+        "ReturnType":  "void",
+        "Name":  "EVT_FAST_PROC_END_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x138f",
+        "ReturnType":  "void",
+        "Name":  "FLD_MODEL_CLEAR_ANIM_EFF",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x1390",
+        "ReturnType":  "void",
+        "Name":  "FLD_ROADMAP_MMAP_CLOSE_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    }
+]

--- a/Source/AtlusScriptLibrary/Libraries/Persona5Royal/Modules/Net/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona5Royal/Modules/Net/Functions.json
@@ -1,0 +1,102 @@
+[
+    {
+        "Index":  "0x5000",
+        "ReturnType":  "void",
+        "Name":  "NET_SET_AFTER_SCHOOL_ACTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x5001",
+        "ReturnType":  "void",
+        "Name":  "NET_SET_NIGHT_ACTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x5002",
+        "ReturnType":  "void",
+        "Name":  "NET_SET_ANSER_SELECT_NUM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x5003",
+        "ReturnType":  "void",
+        "Name":  "NET_SET_ANSER_SUCCESS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x5004",
+        "ReturnType":  "void",
+        "Name":  "NET_SET_STRATEGY",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x5005",
+        "ReturnType":  "void",
+        "Name":  "NET_SET_STRATEGY_SUCCESS",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x5006",
+        "ReturnType":  "void",
+        "Name":  "NET_START_AUDIENCE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x5007",
+        "ReturnType":  "void",
+        "Name":  "NET_STOP_AUDIENCE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    }
+]

--- a/Source/AtlusScriptLibrary/Libraries/Persona5Royal/Modules/Social/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona5Royal/Modules/Social/Functions.json
@@ -1,0 +1,2773 @@
+[
+    {
+        "Index":  "0x3000",
+        "ReturnType":  "void",
+        "Name":  "CALL_EVENT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3001",
+        "ReturnType":  "void",
+        "Name":  "EVT_ASSET_OVERWRITE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param7",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param8",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3002",
+        "ReturnType":  "int",
+        "Name":  "EVT_GET_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3003",
+        "ReturnType":  "int",
+        "Name":  "EVT_GET_ASSET_RESHND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3004",
+        "ReturnType":  "void",
+        "Name":  "CHARA_CAMERA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3005",
+        "ReturnType":  "int",
+        "Name":  "EVT_GET_ANIMCOUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3006",
+        "ReturnType":  "int",
+        "Name":  "EVT_GET_ANIMCOUNT_U",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3007",
+        "ReturnType":  "int",
+        "Name":  "EVT_GET_ANIMCOUNT_D",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3008",
+        "ReturnType":  "int",
+        "Name":  "EVT_GET_ANIMCOUNT_L",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3009",
+        "ReturnType":  "int",
+        "Name":  "EVT_GET_ANIMCOUNT_R",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x300a",
+        "ReturnType":  "void",
+        "Name":  "CUTIN_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x300b",
+        "ReturnType":  "void",
+        "Name":  "CUTIN_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x300c",
+        "ReturnType":  "void",
+        "Name":  "CMM_OPEN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x300d",
+        "ReturnType":  "int",
+        "Name":  "CMM_EXIST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x300e",
+        "ReturnType":  "int",
+        "Name":  "CMM_GET_LV",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x300f",
+        "ReturnType":  "void",
+        "Name":  "CMM_LVUP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3010",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_LVUP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3011",
+        "ReturnType":  "void",
+        "Name":  "CMM_ADD_POINT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3012",
+        "ReturnType":  "void",
+        "Name":  "CMM_ADD_POINT_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3013",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_REVERSE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3014",
+        "ReturnType":  "void",
+        "Name":  "CMM_SET_REVERSE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3015",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_BROKEN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3016",
+        "ReturnType":  "void",
+        "Name":  "CMM_SET_BROKEN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3017",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_CALL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3018",
+        "ReturnType":  "void",
+        "Name":  "CMM_SET_PROMISE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3019",
+        "ReturnType":  "int",
+        "Name":  "CMM_GET_PROMISE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x301a",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_PROMISE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x301b",
+        "ReturnType":  "int",
+        "Name":  "CMM_GET_PROMISE_DAY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x301c",
+        "ReturnType":  "void",
+        "Name":  "CMM_SETUP_EVENT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x301d",
+        "ReturnType":  "void",
+        "Name":  "CMM_EXEC_EVENT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x301e",
+        "ReturnType":  "int",
+        "Name":  "CMM_GET_EVENT_TYPE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x301f",
+        "ReturnType":  "void",
+        "Name":  "CMM_VSET_COMMUNITY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3020",
+        "ReturnType":  "int",
+        "Name":  "CMM_VSET_PS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3021",
+        "ReturnType":  "int",
+        "Name":  "CMM_VSET_PSID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3022",
+        "ReturnType":  "void",
+        "Name":  "CMM_FRIEND",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3023",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_EVENT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3024",
+        "ReturnType":  "void",
+        "Name":  "CMM_ACTIVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3025",
+        "ReturnType":  "int",
+        "Name":  "CMM_GET_LOVER_HIGH",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3026",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_ARCANA_PSSTOCKLV",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3027",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_INVITE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3028",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_FIX_INVITE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3029",
+        "ReturnType":  "void",
+        "Name":  "CMM_SET_INVITE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x302a",
+        "ReturnType":  "int",
+        "Name":  "CMM_CNV_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x302b",
+        "ReturnType":  "int",
+        "Name":  "CMM_GET_CLUB",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x302c",
+        "ReturnType":  "void",
+        "Name":  "CMM_ARBEIT_PAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x302d",
+        "ReturnType":  "int",
+        "Name":  "CMM_ARBEIT_PAY_RECEIVE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x302e",
+        "ReturnType":  "int",
+        "Name":  "CMM_ARBEIT_GET_MONEY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x302f",
+        "ReturnType":  "void",
+        "Name":  "CMM_RANKUP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3030",
+        "ReturnType":  "void",
+        "Name":  "CMM_EVERY_DAY_UPDATE_SUDDEN_DEATH",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3031",
+        "ReturnType":  "void",
+        "Name":  "CMM_INC_SUDDEN_DEATH_COUNT",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3032",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_SUDDEN_DEATH_DOUBT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3033",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_SUDDEN_DEATH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3034",
+        "ReturnType":  "void",
+        "Name":  "CMM_SET_SUDDEN_DEATH_COUNT",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3035",
+        "ReturnType":  "void",
+        "Name":  "CMM_DEC_SUDDEN_DEATH_COUNT",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3036",
+        "ReturnType":  "void",
+        "Name":  "CMM_SET_SUDDEN_DEATH_FLAGT",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3037",
+        "ReturnType":  "void",
+        "Name":  "CMM_RESET_SUDDEN_DEATH_FLAG",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3038",
+        "ReturnType":  "void",
+        "Name":  "CMM_GET_PERSONA_DAY_TIME_SKILL",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3039",
+        "ReturnType":  "int",
+        "Name":  "CMM_MO_GET_INDEX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x303a",
+        "ReturnType":  "int",
+        "Name":  "CMM_MO_CHK_DAY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x303b",
+        "ReturnType":  "int",
+        "Name":  "CMM_MO_CHK_DAY_RECEIVE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x303c",
+        "ReturnType":  "int",
+        "Name":  "CMM_MO_GET_MONEY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x303d",
+        "ReturnType":  "int",
+        "Name":  "CMM_MO_SET_ITEM",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x303e",
+        "ReturnType":  "void",
+        "Name":  "CMM_MO_VSET",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x303f",
+        "ReturnType":  "void",
+        "Name":  "CMM_DEC2_SUDDEN_DEATH_COUNT",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3040",
+        "ReturnType":  "void",
+        "Name":  "CMM_START_AUTO_COMMAND",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3041",
+        "ReturnType":  "int",
+        "Name":  "CMM_SYNC_AUTO_COMMAND",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3042",
+        "ReturnType":  "void",
+        "Name":  "CMM_NEWS_PAPER",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3043",
+        "ReturnType":  "void",
+        "Name":  "CMM_NEWS_PAPER_SYNC",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3044",
+        "ReturnType":  "void",
+        "Name":  "MISSION_START",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3045",
+        "ReturnType":  "void",
+        "Name":  "MISSION_START_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3046",
+        "ReturnType":  "void",
+        "Name":  "MISSION_END",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3047",
+        "ReturnType":  "void",
+        "Name":  "MISSION_SCRIPT_EXEC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3048",
+        "ReturnType":  "void",
+        "Name":  "LBX_IN_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3049",
+        "ReturnType":  "void",
+        "Name":  "LBX_IN_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x304a",
+        "ReturnType":  "void",
+        "Name":  "LBX_OUT_START",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x304b",
+        "ReturnType":  "void",
+        "Name":  "LBX_OUT_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x304c",
+        "ReturnType":  "void",
+        "Name":  "CUTIN_START2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x304d",
+        "ReturnType":  "void",
+        "Name":  "CUTIN_START3",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x304e",
+        "ReturnType":  "void",
+        "Name":  "CUTIN_START4",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param7",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x304f",
+        "ReturnType":  "void",
+        "Name":  "CALL_EVENT_TEST",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3050",
+        "ReturnType":  "void",
+        "Name":  "EVT_MONOTONE_START",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3051",
+        "ReturnType":  "void",
+        "Name":  "EVT_MONOTONE_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3052",
+        "ReturnType":  "void",
+        "Name":  "EVT_MODEL_ADD_ROTATE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3053",
+        "ReturnType":  "void",
+        "Name":  "CALL_EVENT_PREPARE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3054",
+        "ReturnType":  "void",
+        "Name":  "CHAT_WAIT_PAD",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3055",
+        "ReturnType":  "void",
+        "Name":  "CHAT_SEL_LINE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3056",
+        "ReturnType":  "void",
+        "Name":  "CHAT_SET_SEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3057",
+        "ReturnType":  "int",
+        "Name":  "CHAT_GET_SEL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3058",
+        "ReturnType":  "void",
+        "Name":  "CALL_BOOK_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3059",
+        "ReturnType":  "int",
+        "Name":  "CMM_BOOK_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x305a",
+        "ReturnType":  "int",
+        "Name":  "CMM_BOOK_SEARCH",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x305b",
+        "ReturnType":  "int",
+        "Name":  "CMM_BOOK_ACCESS",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x305c",
+        "ReturnType":  "int",
+        "Name":  "CMM_BOOK_READ_END",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x305d",
+        "ReturnType":  "int",
+        "Name":  "CHAT_CHECK_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x305e",
+        "ReturnType":  "void",
+        "Name":  "CHAT_SET_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x305f",
+        "ReturnType":  "int",
+        "Name":  "CMM_BOOK_SIZE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3060",
+        "ReturnType":  "int",
+        "Name":  "CMM_RAPID_BUTTON_ACTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3061",
+        "ReturnType":  "int",
+        "Name":  "CMM_DAICE_BUTTON_ACTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3062",
+        "ReturnType":  "int",
+        "Name":  "CMM_GOLF_BUTTON_ACTION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3063",
+        "ReturnType":  "void",
+        "Name":  "CMM_SET_INVITE_COUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3064",
+        "ReturnType":  "int",
+        "Name":  "CMM_GET_INVITE_COUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3065",
+        "ReturnType":  "void",
+        "Name":  "CMM_COUNTUP_REVERSE_DAY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3066",
+        "ReturnType":  "int",
+        "Name":  "CMM_GET_REVERSE_DAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3067",
+        "ReturnType":  "void",
+        "Name":  "CMM_START_REVERSE_RENDITION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3068",
+        "ReturnType":  "void",
+        "Name":  "CMM_START_CANCEL_REVERSE_RENDITION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3069",
+        "ReturnType":  "void",
+        "Name":  "CMM_START_BROKEN_RENDITION",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x306a",
+        "ReturnType":  "void",
+        "Name":  "CMM_FUNC_LIST_DRAW_START",
+        "Description":  "Empty function",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x306b",
+        "ReturnType":  "void",
+        "Name":  "CMM_FUNC_LIST_DRAW_END",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x306c",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHECK_NOW_ACTIVE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x306d",
+        "ReturnType":  "int",
+        "Name":  "CMM_FLAG_CONVERT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x306e",
+        "ReturnType":  "void",
+        "Name":  "CMM_AREA_NAME_DISP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x306f",
+        "ReturnType":  "void",
+        "Name":  "CMM_TIMEWARP",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3070",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHECK_ENABLE_FUNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3071",
+        "ReturnType":  "void",
+        "Name":  "EVT_SET_LOCAL_COUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3072",
+        "ReturnType":  "int",
+        "Name":  "EVT_GET_LOCAL_COUNT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3073",
+        "ReturnType":  "int",
+        "Name":  "CHAT_CHECK_ARRIVAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3074",
+        "ReturnType":  "int",
+        "Name":  "CHAT_GET_ARRIVAL_TIME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3075",
+        "ReturnType":  "int",
+        "Name":  "CHAT_CHECK_PASS_TIME_ARRIVAL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3076",
+        "ReturnType":  "void",
+        "Name":  "CALL_STAFF_ROLL",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3077",
+        "ReturnType":  "void",
+        "Name":  "EVT_SET_LOCAL_DATA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3078",
+        "ReturnType":  "int",
+        "Name":  "EVT_GET_LOCAL_DATA",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3079",
+        "ReturnType":  "int",
+        "Name":  "CMM_RAPID_BUTTON_ACTION2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x307a",
+        "ReturnType":  "int",
+        "Name":  "CMM_DAICE_BUTTON_ACTION2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x307b",
+        "ReturnType":  "int",
+        "Name":  "CMM_DAICE_BUTTON_GET_DAICE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x307c",
+        "ReturnType":  "int",
+        "Name":  "CMM_GOLF_BUTTON_ACTION2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x307d",
+        "ReturnType":  "int",
+        "Name":  "CMM_COMMAND_BUTTON_ACTION2",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x307e",
+        "ReturnType":  "void",
+        "Name":  "CMM_INTERROGATION_IN",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x307f",
+        "ReturnType":  "void",
+        "Name":  "CMM_SET_LV",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3080",
+        "ReturnType":  "void",
+        "Name":  "INIT_IME_DRIVER",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3081",
+        "ReturnType":  "void",
+        "Name":  "END_IME_DRIVER",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3082",
+        "ReturnType":  "void",
+        "Name":  "EVT_SE_PLAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3083",
+        "ReturnType":  "void",
+        "Name":  "EVT_SE_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3084",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_EPL_READ",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3085",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_EPL_READ_SYNC",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3086",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_EPL_FREE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3087",
+        "ReturnType":  "void",
+        "Name":  "KFEVT_EPL_PLAY",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3088",
+        "ReturnType":  "int",
+        "Name":  "GET_CHAT_INVITE_TIMING",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3089",
+        "ReturnType":  "void",
+        "Name":  "MDL_ANIM_LINK_EVTSE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x308a",
+        "ReturnType":  "void",
+        "Name":  "INVITE_WORK_INIT",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x308b",
+        "ReturnType":  "void",
+        "Name":  "SET_INVITE_WORK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "float",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x308c",
+        "ReturnType":  "int",
+        "Name":  "GET_INVITE_WORK",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x308d",
+        "ReturnType":  "int",
+        "Name":  "GET_INVITE_CORP_MAX",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x308e",
+        "ReturnType":  "void",
+        "Name":  "EVT_SET_LOG_DISP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x308f",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHECK_ENABLE_FUNC_DETAIL",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3090",
+        "ReturnType":  "int",
+        "Name":  "GET_PM_CHAT_INVITE_TYPE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3091",
+        "ReturnType":  "void",
+        "Name":  "CMM_TIMEWARP_FADE",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3092",
+        "ReturnType":  "int",
+        "Name":  "CHECK_PUBLIC_HOLIDAY_NEXTDAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3093",
+        "ReturnType":  "void",
+        "Name":  "SET_STR_PUBLIC_HOLIDAY_NEXTDAY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3094",
+        "ReturnType":  "int",
+        "Name":  "GET_CONQUEST_DUNGEON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3095",
+        "ReturnType":  "int",
+        "Name":  "GET_DUNGEON_INVITE_CHAT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "float",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3096",
+        "ReturnType":  "void",
+        "Name":  "EVT_SET_ENABLE_CTRL_KEY",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3097",
+        "ReturnType":  "void",
+        "Name":  "MSG_BACKLOG_PAUSE_ON",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3098",
+        "ReturnType":  "void",
+        "Name":  "MSG_BACKLOG_PAUSE_OFF",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x3099",
+        "ReturnType":  "void",
+        "Name":  "EVT_LEADING_REQUEST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x309a",
+        "ReturnType":  "void",
+        "Name":  "EVT_SET_SKIP_KEEP_FLAG",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  "Alias of 0x309b EVT_GET_SKIP_KEEP_FLAG"
+    },
+    {
+        "Index":  "0x309b",
+        "ReturnType":  "void",
+        "Name":  "EVT_GET_SKIP_KEEP_FLAG",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  "Alias of 0x309a EVT_SET_SKIP_KEEP_FLAG"
+    },
+    {
+        "Index":  "0x309c",
+        "ReturnType":  "void",
+        "Name":  "EVT_MSG_LOG_CLEAR",
+        "Description":  "Empty function",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x309d",
+        "ReturnType":  "void",
+        "Name":  "EVT_FAST_PROC_START",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x309e",
+        "ReturnType":  "void",
+        "Name":  "EVT_FAST_PROC_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x309f",
+        "ReturnType":  "void",
+        "Name":  "EVT_FAST_CANCEL_REQ",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30a0",
+        "ReturnType":  "void",
+        "Name":  "CMM_MEMORY_GAME_SET_BUTTON",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param6",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param7",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param8",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30a1",
+        "ReturnType":  "void",
+        "Name":  "CMM_MEMORY_GAME_SET_TIME",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30a2",
+        "ReturnType":  "int",
+        "Name":  "CMM_MEMORY_GAME_START",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30a3",
+        "ReturnType":  "void",
+        "Name":  "CMM_CHANGE_ARCANA_YOSIZAWA",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30a4",
+        "ReturnType":  "void",
+        "Name":  "CMM_CHANGE_DISP_ID",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30a5",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_RANKUP_EVENT_NEXT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30a6",
+        "ReturnType":  "int",
+        "Name":  "CMM_CHK_INSERT_EVENT_RUBURAN",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30a7",
+        "ReturnType":  "void",
+        "Name":  "EVT_CA_START",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30a8",
+        "ReturnType":  "void",
+        "Name":  "EVT_CA_END",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30a9",
+        "ReturnType":  "void",
+        "Name":  "EVT_SET_KFREE_SETTING",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30aa",
+        "ReturnType":  "int",
+        "Name":  "CMM_HOLIDAY_INVITE_CHATNO",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param4",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param5",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30ab",
+        "ReturnType":  "void",
+        "Name":  "EVT_CA_BUTTON_ANIME",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30ac",
+        "ReturnType":  "void",
+        "Name":  "EVT_MOVIE_SEEK_SYNC",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30ad",
+        "ReturnType":  "void",
+        "Name":  "EVT_LEADING_REQUEST_TABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30ae",
+        "ReturnType":  "void",
+        "Name":  "CMM_DELETE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30af",
+        "ReturnType":  "int",
+        "Name":  "CMM_GET_POINT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30b0",
+        "ReturnType":  "int",
+        "Name":  "CMM_GET_NEXT_POINT",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30b1",
+        "ReturnType":  "void",
+        "Name":  "EVT_PAUSE_PADOK_DISABLE",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30b2",
+        "ReturnType":  "void",
+        "Name":  "CMM_ADD_POINT_ID_ST",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param2",
+                               "Description":  ""
+                           },
+                           {
+                               "Type":  "int",
+                               "Name":  "param3",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30b3",
+        "ReturnType":  "void",
+        "Name":  "CMM_SYNC_POINT_ID_ST",
+        "Description":  "",
+        "Parameters":  [],
+        "Comment":  ""
+    },
+    {
+        "Index":  "0x30b4",
+        "ReturnType":  "void",
+        "Name":  "EVT_BACKLOG_STOP",
+        "Description":  "",
+        "Parameters":  [
+                           {
+                               "Type":  "int",
+                               "Name":  "param1",
+                               "Description":  ""
+                           }
+                       ],
+        "Comment":  ""
+    }
+]


### PR DESCRIPTION
Lots of new functions compared to vanilla P5:

| Section | Name     | P5   | P5R  |
| --------|----------|------|------|
| 0       | Common   | 373  | 421  |
| 1       | Field    | 822  | 913  |
| 2       | AI       | 411  | 461  |
| 3       | Social   | 151  | 181  |
| 4       | Facility | 113  | 175  |
| 5       | Net      | 8    | 8    |
| -       | Total    | 1878 | 2159 |

---

Some notes:

1. 20 functions are null pointers.
2. 78 functions are "empty" (`return 1;`).
3. There are 13 pairs of function pointer aliases (where each pair points to the same function) - I added a comment for each function that mentions its alias.
4. There are 2 function pairs that have the same name, marked with a `___2` suffix in library.

In the cases of `3.` and `4.`, sometimes aliased functions take a different number of parameters, so these might be overrides or some such (in one case, 2 function pointers have the same name but point to different functions with different signatures).

---

Regarding the code itself - unlike P5 (on both PS3 and PS4), in P5R the script parameter parsing functions and the return value setting functions were all in-lined, which made parsing parameter and return types... difficult :p

I did run a test decompilation of all scripts in the base game + patch v1.02 and they all decompiled successfully. There were also no "detached" return values (`^ +\d+;`) in the output `.flow` files.

I also tested some re-compiled scripts in-game and they worked without any issues (with and without hooking).

---

To use, add `-Library P5R` to `AtlusScriptCompiler` args when (de)compiling.
