### PR TITLE
Handled -1 Substring Exception

### DIFF
--- a/Source/AtlusScriptLibrary/FlowScriptLanguage/Compiler/FlowScriptCompiler.cs
+++ b/Source/AtlusScriptLibrary/FlowScriptLanguage/Compiler/FlowScriptCompiler.cs
@@ -1895,7 +1895,8 @@ namespace AtlusScriptLibrary.FlowScriptLanguage.Compiler
                 if ( !TryEmitProcedureCall( callExpression, isStatement, procedure ) )
                     return false;
             }
-            else if ( ProcedureHookMode != ProcedureHookMode.None && 
+            else if ( ProcedureHookMode != ProcedureHookMode.None
+                && callExpression.Identifier.Text.IndexOf("_unhooked") != -1 &&
                 mRootScope.TryGetProcedure( callExpression.Identifier.Text.Substring(0, 
                     callExpression.Identifier.Text.IndexOf("_unhooked") ), out procedure ))
             {


### PR DESCRIPTION
This prevents the compiler from throwing an uncaught exception when the function name isn't found. This happened because IndexOf() returns -1 if the string isn't found and -1 can't be used for the ending position of the Substring() function. (This is the same error that caused p4gpc.modloader to crash with a loose file in the mods folder, which hopefully you can update in [sewer56's Nuget repository](http://packages.sewer56.moe/upload))