### PR TITLE
P3P: Label CMM_CHK_LVUP function

### DIFF
--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Event/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Event/Functions.json
@@ -192,14 +192,17 @@
   {
     "Index": "0x300f",
     "ReturnType": "int",
-    "Name": "EVT_FUNCTION_000F",
-    "Description": "Address: 0x08A5F44C",
+    "Name": "CMM_CHK_LVUP",
+    "Description": "Check if a social link is ready to rank up. Does not check if they are actually available.",
     "Parameters": [
       {
         "Type": "int",
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_000F"
     ]
   },
   {


### PR DESCRIPTION
When my bf emulator fork was merged in #67 some library changes were lost, seemingly mainly for P3P. Because I've now updated BF Emulator to use the main branch one of these library changes has broken a few P3P mods. 
Funnily enough, literally only one of the renamed functions seems to have been used in any mods so I've just added that one for now. The others can be added back later, I'm not convinced that they were all actually correct.