### PR TITLE
Document multiple functions in P3P Library's "Common" module

### DIFF
--- a/Source/AtlusScriptLibrary/Common/Libraries/LibraryLookup.cs
+++ b/Source/AtlusScriptLibrary/Common/Libraries/LibraryLookup.cs
@@ -51,10 +51,22 @@ public static class LibraryLookup
         EnsureInitialized();
 
         if (sLibrariesByShortName.TryGetValue(name, out var value))
+        {
+            foreach(FlowScriptModule module in value.FlowScriptModules)
+            {
+                module.Functions = module.Functions.OrderBy(x => x.Index).ToList();
+            }
             return value;
+        }
 
         if (sLibrariesByFullName.TryGetValue(name, out value))
+        {
+            foreach(FlowScriptModule module in value.FlowScriptModules)
+            {
+                module.Functions = module.Functions.OrderBy(x => x.Index).ToList();
+            }
             return value;
+        }
 
         return null;
     }

--- a/Source/AtlusScriptLibrary/FlowScriptLanguage/Compiler/FlowScriptCompiler.cs
+++ b/Source/AtlusScriptLibrary/FlowScriptLanguage/Compiler/FlowScriptCompiler.cs
@@ -2227,9 +2227,7 @@ public class FlowScriptCompiler
 
         if (mRootScope.TryGetFunction(callExpression.Identifier.Text, out var function))
         {
-            var libFunc = Library.FlowScriptModules.SelectMany(x => x.Functions).FirstOrDefault(x => x.Name == function.Declaration.Identifier.Text || (x.Aliases != null && x.Aliases.Contains(function.Declaration.Identifier.Text)));
-
-            // Add default values
+            // Add default values from first detected function in library with a name or alias that matches the call
             var foundDefaultValue = false;
             for (var i = 0; i < function.Declaration.Parameters.Count; i++)
             {
@@ -2255,32 +2253,31 @@ public class FlowScriptCompiler
                 }
             }
 
-            // Check if call has correct number of parameters
-            if (callExpression.Arguments.Count != function.Declaration.Parameters.Count)
+            // Get a function that has the same number of arguments as the callExpression or is variadic and has a matching name or alias
+            var libFunc = Library.FlowScriptModules.SelectMany(x => x.Functions).FirstOrDefault(x => (x.Parameters.Count == callExpression.Arguments.Count || x.Semantic == FlowScriptModuleFunctionSemantic.Variadic) && (x.Name == function.Declaration.Identifier.Text || (x.Aliases != null && x.Aliases.Contains(function.Declaration.Identifier.Text))));
+            // If libFunc is null, then no function that is variadic or has a matching amount of parameters with the same name or alias was found
+            // Throw an error and return false
+            if (libFunc == null)
             {
-                // Check if function is marked variadic
-                if (libFunc == null || libFunc.Semantic != FlowScriptModuleFunctionSemantic.Variadic)
-                {
-                    // Check if a different function has an alias that matches and
-                    // with same number of params as callExpression.Arguments.Count
-                    if (!mRootScope.TryGetFunction(Library.FlowScriptModules.SelectMany(x => x.Functions).FirstOrDefault(x => x.Parameters.Count == callExpression.Arguments.Count && x.Aliases != null && x.Aliases.Contains(function.Declaration.Identifier.Text)).Name, out var altFunction))
-                    {
-                        // Function was not variadic and no alternative with matching number of
-                        // parameters & an alias was found, so throw an error and return false emit
-                        Error(callExpression, $"Function '{function.Declaration}' expects {function.Declaration.Parameters.Count} arguments but {callExpression.Arguments.Count} are given");
-                        return false;
-                    }
-                    /*
-                        An alternative function was found with matching number of parameters & an alias,
-                        so override function variable with it
-
-                        Also prints a warning message as this situation occurs when compiling scripts
-                        that weren't updated to use current/non-conflicting names, to let authors/users know
-                        that the script should be updated so that this scenario never occurs in the first place
-                    */
-                    Warning(callExpression, $"Function '{function.Declaration}' called with number of parameters and an alias name of '{altFunction.Declaration}';\n'{altFunction.Declaration}' will be emitted but script should be updated with correct function names!");
-                    function = altFunction;
-                }
+                Error(callExpression, $"Function '{function.Declaration}' expects {function.Declaration.Parameters.Count} arguments but {callExpression.Arguments.Count} are given");
+                return false;
+            }
+            /*
+                If the initially detected function name does not match with libFunc.Name and the number of arguments differs and is not Variadic,
+                assume that what has happened is that a function was called using the number of arguments of another function that has a matching Alias.
+                This should only occur in the following scenario:
+                    Function A that has X arguments is named "A"
+                    Function B that has Y arguments is named "B", but used to be named "A" and has it as an Alias
+                    Calls written with Function A's name and the number of arguments of Function B will be assigned to Function B, as it has a matching Alias
+                If this scenario does occur, we log a warning to encourage script authors to update their scripts to use the current names either when
+                they compile their script or when users of their flowscript merging mods (if applicable) ask them if the warning is an issue.
+                The only reason we don't just throw a hard error is so that in cases of abandoned mods users aren't forced to manually fix their mods
+                on their own, risking breaking something in the process and resulting in unnecessary troubleshooting downstream and up.
+            */
+            if (callExpression.Identifier.Text != libFunc.Name && (callExpression.Arguments.Count != function.Declaration.Parameters.Count && libFunc.Semantic != FlowScriptModuleFunctionSemantic.Variadic))
+            {
+                Warning(callExpression, $"Function '{callExpression.Identifier.Text}' called with number of parameters and alias name of '{libFunc.Name}';\n'{libFunc.Name}' will be emitted but script should be updated with correct function names!");
+                mLogger.Debug($"TryGetFunction reassignment returned: {mRootScope.TryGetFunction(libFunc.Name, out function)}");
             }
 
             // Check MessageScript function call semantics

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
@@ -9,6 +9,8 @@
         "Type": "int",
         "Name": "param1",
         "Description": "",
+        "Name": "messageID",
+        "Description": "Index of message to display",
         "Semantic": "MsgId"
       }
     ],
@@ -46,6 +48,8 @@
         "Type": "int",
         "Name": "param1",
         "Description": "",
+        "Name": "selMessageID",
+        "Description": "Index of SEL message to use",
         "Semantic": "SelId"
       }
     ],

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
@@ -7,8 +7,6 @@
     "Parameters": [
       {
         "Type": "int",
-        "Name": "param1",
-        "Description": "",
         "Name": "messageID",
         "Description": "Index of message to display",
         "Semantic": "MsgId"
@@ -46,8 +44,6 @@
     "Parameters": [
       {
         "Type": "int",
-        "Name": "param1",
-        "Description": "",
         "Name": "selMessageID",
         "Description": "Index of SEL message to use",
         "Semantic": "SelId"

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
@@ -216,9 +216,12 @@
   {
     "Index": "0x000f",
     "ReturnType": "int",
-    "Name": "FUNCTION_000F",
-    "Description": "Address: 0x08978F28",
-    "Parameters": []
+    "Name": "FADE_SYNC",
+    "Description": "Waits until any playing fade animation finishes",
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_000F"
+    ]
   },
   {
     "Index": "0x0010",

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
@@ -832,26 +832,26 @@
     "Index": "0x0035",
     "ReturnType": "int",
     "Name": "CHK_DAYS_STARTEND",
-    "Description": "Address: 0x08972B8C",
+    "Description": "Returns true if within the two dates",
     "Parameters": [
       {
         "Type": "int",
-        "Name": "param1",
+        "Name": "month1",
         "Description": ""
       },
       {
         "Type": "int",
-        "Name": "param2",
+        "Name": "day1",
         "Description": ""
       },
       {
         "Type": "int",
-        "Name": "param3",
+        "Name": "month2",
         "Description": ""
       },
       {
         "Type": "int",
-        "Name": "param4",
+        "Name": "day2",
         "Description": ""
       }
     ],
@@ -983,11 +983,11 @@
     "Index": "0x0040",
     "ReturnType": "void",
     "Name": "PARTY_IN",
-    "Description": "Address: 0x089734F8",
+    "Description": "Adds given party member id to party",
     "Parameters": [
       {
         "Type": "PartyMember",
-        "Name": "param1",
+        "Name": "id",
         "Description": ""
       }
     ],
@@ -999,11 +999,11 @@
     "Index": "0x0041",
     "ReturnType": "void",
     "Name": "PARTY_OUT",
-    "Description": "Address: 0x089735BC",
+    "Description": "Removes given party member id from party",
     "Parameters": [
       {
         "Type": "PartyMember",
-        "Name": "param1",
+        "Name": "id",
         "Description": ""
       }
     ],
@@ -1410,43 +1410,43 @@
   {
     "Index": "0x0064",
     "ReturnType": "void",
-    "Name": "NAVI_OPEN",
-    "Description": "Opens navigator bustup with parameters deciding which one to show.",
+    "Name": "CUTIN_START",
+    "Description": "Opens cutin with parameters deciding which one to show",
     "Parameters": [
       {
         "Type": "int",
-        "Name": "param1",
-        "Description": ""
+        "Name": "slotIndex",
+        "Description": "Start cutin loaded into this slot"
       },
       {
         "Type": "int",
-        "Name": "param2",
-        "Description": ""
+        "Name": "xPos",
+        "Description": "X position of cutin"
       },
       {
         "Type": "int",
-        "Name": "param3",
-        "Description": ""
+        "Name": "yPos",
+        "Description": "Y position of cutin"
       },
       {
         "Type": "int",
-        "Name": "param4",
-        "Description": "6 is Fuuka, 4 is Mitsuru."
+        "Name": "characterID",
+        "Description": "6 is Fuuka, 4 is Mitsuru. CX_0"
       },
       {
         "Type": "int",
-        "Name": "param5",
-        "Description": ""
+        "Name": "emotionID",
+        "Description": "C0_X"
       },
       {
         "Type": "int",
         "Name": "param6",
-        "Description": "Unknown type; assumed int"
+        "Description": "Appears to be ignored/unused. Unknown type; assumed int"
       },
       {
         "Type": "int",
         "Name": "param7",
-        "Description": "Unknown type; assumed int"
+        "Description": "Appears to be ignored/unused. Unknown type; assumed int"
       }
     ],
     "Aliases": [
@@ -1456,13 +1456,13 @@
   {
     "Index": "0x0065",
     "ReturnType": "void",
-    "Name": "NAVI_CLOSE",
-    "Description": "Closes navigator bustup.",
+    "Name": "CUTIN_STOP",
+    "Description": "Closes a loaded cutin",
     "Parameters": [
       {
         "Type": "int",
-        "Name": "param1",
-        "Description": ""
+        "Name": "slotIndex",
+        "Description": "Close cutin loaded in this slot"
       }
     ],
     "Aliases": [

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
@@ -182,20 +182,23 @@
   {
     "Index": "0x000d",
     "ReturnType": "void",
-    "Name": "FUNCTION_000D",
-    "Description": "Address: 0x08979C98",
+    "Name": "FADEIN",
+    "Description": "Play last used FADEOUT (preserving colours if it was FADE_COLOR) animation, but reversed to fade in screen",
     "Parameters": [
       {
         "Type": "int",
-        "Name": "param1",
-        "Description": ""
+        "Name": "length",
+        "Description": "Number of frames animation should last (30 = 1s)"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000D"
     ]
   },
   {
     "Index": "0x000e",
     "ReturnType": "void",
-    "Name": "FADE",
+    "Name": "FADEOUT",
     "Description": "Play an animation which fades out the screen, typically used for scene transitions",
     "Parameters": [
       {
@@ -210,6 +213,7 @@
       }
     ],
     "Aliases": [
+      "FADE",
       "FUNCTION_000E"
     ]
   },
@@ -226,34 +230,37 @@
   {
     "Index": "0x0010",
     "ReturnType": "void",
-    "Name": "FUNCTION_0010",
-    "Description": "Address: 0x08979D70",
+    "Name": "FADE_COLOR",
+    "Description": "Play an animation which fades out the screen, using a specific color for the effect",
     "Parameters": [
       {
         "Type": "int",
-        "Name": "param1",
+        "Name": "animType",
+        "Description": "Determines which fade animation to play"
+      },
+      {
+        "Type": "int",
+        "Name": "length",
+        "Description": "Number of frames animation should last (30 = 1s)"
+      },
+      {
+        "Type": "int",
+        "Name": "red",
         "Description": ""
       },
       {
         "Type": "int",
-        "Name": "param2",
+        "Name": "green",
         "Description": ""
       },
       {
         "Type": "int",
-        "Name": "param3",
-        "Description": ""
-      },
-      {
-        "Type": "int",
-        "Name": "param4",
-        "Description": ""
-      },
-      {
-        "Type": "int",
-        "Name": "param5",
+        "Name": "blue",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0010"
     ]
   },
   {
@@ -542,11 +549,11 @@
     "Index": "0x0022",
     "ReturnType": "void",
     "Name": "BGM",
-    "Description": "Address: 0x0897939C",
+    "Description": "Plays bgm based on id (XX.ADX). Note that only IDs in a hard-coded list will actually play",
     "Parameters": [
       {
         "Type": "int",
-        "Name": "param1",
+        "Name": "id",
         "Description": ""
       }
     ],
@@ -738,14 +745,18 @@
   {
     "Index": "0x002d",
     "ReturnType": "void",
-    "Name": "FUNCTION_002D",
-    "Description": "Address: 0x08986A78",
+    "Name": "MSG_TUTORIAL",
+    "Description": "Displays msg on help screen",
     "Parameters": [
       {
         "Type": "int",
         "Name": "param1",
-        "Description": ""
+        "Description": "Index/name of msg to display",
+        "Semantic": "MsgId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_002D"
     ]
   },
   {
@@ -788,49 +799,62 @@
   {
     "Index": "0x0030",
     "ReturnType": "int",
-    "Name": "FUNCTION_0030",
-    "Description": "Address: 0x089729B0",
-    "Parameters": []
+    "Name": "GET_MONTH",
+    "Description": "Returns the current month",
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0030"
+    ]
   },
   {
     "Index": "0x0031",
     "ReturnType": "int",
-    "Name": "FUNCTION_0031",
-    "Description": "Address: 0x089729EC",
-    "Parameters": []
+    "Name": "GET_DAY",
+    "Description": "Returns the current day of the month",
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0031"
+    ]
   },
   {
     "Index": "0x0032",
     "ReturnType": "int",
-    "Name": "FUNCTION_0032",
-    "Description": "Address: 0x08972A28",
-    "Parameters": []
+    "Name": "GET_DAYOFWEEK",
+    "Description": "Returns the current day of the week",
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0032"
+    ]
   },
   {
     "Index": "0x0033",
     "ReturnType": "int",
-    "Name": "FUNCTION_0033",
-    "Description": "Address: 0x08972A58",
-    "Parameters": []
+    "Name": "GET_TIME",
+    "Description": "Returns current time of day",
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0033"
+    ]
   },
   {
     "Index": "0x0034",
     "ReturnType": "int",
-    "Name": "GET_DAY",
-    "Description": "Address: 0x08972A88",
+    "Name": "CHK_DAYS",
+    "Description": "Checks if on a specific month & day. TODO: Confirm this, and figure out if the alias system will allow using GET_DAY as an alias and as the name for FUNCTION_0031. Also what values does it return",
     "Parameters": [
       {
         "Type": "int",
-        "Name": "param1",
+        "Name": "month",
         "Description": ""
       },
       {
         "Type": "int",
-        "Name": "param2",
+        "Name": "day",
         "Description": ""
       }
     ],
     "Aliases": [
+      "GET_DAY",
       "FUNCTION_0034"
     ]
   },
@@ -1456,6 +1480,7 @@
       }
     ],
     "Aliases": [
+      "NAVI_OPEN",
       "FUNCTION_0064"
     ]
   },
@@ -1472,6 +1497,7 @@
       }
     ],
     "Aliases": [
+      "NAVI_CLOSE",
       "FUNCTION_0065"
     ]
   },

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
@@ -76,14 +76,17 @@
   {
     "Index": "0x0006",
     "ReturnType": "void",
-    "Name": "FUNCTION_0006",
-    "Description": "Address: 0x08982784",
+    "Name": "SEL_MASK",
+    "Description": "Sets bit mask for SEL",
     "Parameters": [
       {
         "Type": "int",
-        "Name": "param1",
-        "Description": ""
+        "Name": "bitMask",
+        "Description": "Each bit (rightmost to leftmost) corresponds to options top to bottom (ie 0b0001 hides first option, 0b0010 hides second etc.)"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0006"
     ]
   },
   {

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
@@ -196,17 +196,17 @@
     "Index": "0x000e",
     "ReturnType": "void",
     "Name": "FADE",
-    "Description": "Address: 0x08979CF8",
+    "Description": "Play an animation which fades out the screen, typically used for scene transitions",
     "Parameters": [
       {
         "Type": "int",
-        "Name": "param1",
-        "Description": ""
+        "Name": "animType",
+        "Description": "Determines which fade animation to play"
       },
       {
         "Type": "int",
-        "Name": "param2",
-        "Description": ""
+        "Name": "length",
+        "Description": "Number of frames animation should last (30 = 1s)"
       }
     ],
     "Aliases": [

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
@@ -840,7 +840,7 @@
     "Index": "0x0034",
     "ReturnType": "int",
     "Name": "CHK_DAYS",
-    "Description": "Checks if on a specific month & day. TODO: Confirm this, and figure out if the alias system will allow using GET_DAY as an alias and as the name for FUNCTION_0031. Also what values does it return",
+    "Description": "Checks if on a specific month & day, returning true/1 if so and 0 otherwise",
     "Parameters": [
       {
         "Type": "int",

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Field/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Field/Functions.json
@@ -204,13 +204,14 @@
     "Parameters": [
       {
         "Type": "int",
-        "Name": "param1",
-        "Description": ""
+        "Name": "characterID",
+        "Description": "ID of character icon to display with message (umd0/font/jm_k*)"
       },
       {
         "Type": "int",
-        "Name": "param2",
-        "Description": ""
+        "Name": "messageID",
+        "Description": "Index of message to display",
+        "Semantic": "MsgId"
       }
     ],
     "Aliases": [


### PR DESCRIPTION
Got reminded that there are a lot of functions that I have (if only mostly) figured out that I never got around to actually documenting here. These aren't all of those to be clear, just the ones that I have specifically tested prior to making this PR so that I can confirm that my documentation is accurate, hopefully though I can get around to the rest eventually.

This PR names and gives accompanying documentation (descriptions in the "Description" field, and named function parameters with descriptions for those when necessary) to the following unnamed functions:
* `FUNCTION_0006` -> `SEL_MASK`
* `FUNCTION_000D` -> `FADEIN`
* `FUNCTION_000F` -> `FADE_SYNC`
* `FUNCTION_0010` -> `FADE_COLOR`
* `FUNCTION_002D` -> `MSG_TUTORIAL`
* `FUNCTION_0030` -> `GET_MONTH`
* `FUNCTION_0032` -> `GET_DAYOFWEEK`
* `FUNCTION_0033` -> `GET_TIME`

It also re-names certain functions to be more accurate to how the function works and to match with P5R's library (at least in regards to "does this function clearly serve the same purpose across both of these games"):
* `FADE         ` -> `FADEOUT`
* `NAVI_OPEN    ` -> `CUTIN_START`
* `NAVI_CLOSE   ` -> `CUTIN_STOP`

The following functions were given updated descriptions and/or parameter names but are otherwise unchanged in any significant way:
* `MSG`
* `SEL`
* `CHK_DAYS_STARTEND`
* `PARTY_IN`
* `PARTY_OUT`
* `FLD_START_SUPPORT_MSG`

There is also very unfortunately a mild but still **breaking change** among these, due to the following function name changes:
* `FUNCTION_0031` -> `GET_DAY`
* `GET_DAY      ` -> `CHK_DAYS`

From my own testing, it is very clear that the function of `FUNCTION_0031` is to "get" the current day of the month and return it, and that the function of `GET_DAY` is to take in a month & day value and give a boolean result depending on if the current month & day matches (which aligns with the `CHK_DAYS` function from P5R exactly.)
Therefore I named them as you see above as I know that these names are accurate and correct, but this will prevent any flowscript file that used `GET_DAY` prior to this PR from compiling until the mod author updates the script to use the current name.

Ideally, AST would be able to handle this conflict automatically by being able to detect the `GET_DAY` alias I gave to `CHK_DAYS` and thus compile for that function instead when it sees something like `GET_DAY(4, 7)` in a script, but from my own testing it simply and expectedly throws an error for `GET_DAY` having too many arguments passed. ~~That is out of scope of this PR, though, and if it's deemed better even if only temporarily to just choose a different non-conflicting name for `FUNCTION_0031` instead I can go ahead and do that :)~~

EDIT: I have since looked into whether I could edit the compiler code to add a fix for this issue myself and I was able to add a check that will allow files to still compile even if they use the old function names! Given that such a change goes hand-in-hand with solving the conflict from this library update I decided it was best to push it as an additional commit to this PR. For more details on the check, see [this comment below.](https://github.com/tge-was-taken/Atlus-Script-Tools/pull/108#issuecomment-3354136775)
While I made sure to check that my changes should only ever occur in a situation like this and thus *shouldn't* affect anything anywhere else (I even tested to make sure that BF files compiled before the change matched exactly with ones compiled after), review of my code changes in case I missed something is still very much 